### PR TITLE
Feat: Built-in JSON to PNG Card Converter Tool

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import { openConverterModal } from './json-png-converter.js';
 const EXTENSION_NAME = "Character Library";
 const EXTENSION_DIR = "SillyTavern-CharacterLibrary";
 
@@ -193,6 +194,11 @@ function setupLauncherDropdown() {
             <span>Character Management</span>
         </div>
         <div class="charlib-launcher-divider"></div>
+        
+        <div class="charlib-launcher-item" data-action="converter">
+            <i class="fa-solid fa-file-export"></i>
+            <span>JSON to PNG Converter</span>
+        </div>
         <div class="charlib-launcher-item" data-action="library">
             <i class="fa-solid fa-photo-film"></i>
             <span>Character Library</span>
@@ -282,6 +288,8 @@ function setupLauncherDropdown() {
         if (item.dataset.action === 'native') {
             bypassIntercept = true;
             drawerToggle.click();               // Replay click to ST's handler
+        } else if (item.dataset.action === 'converter') {
+            openConverterModal();
         } else if (item.dataset.action === 'library') {
             openGallery();
         }

--- a/json-png-converter.js
+++ b/json-png-converter.js
@@ -1,0 +1,95 @@
+export function openConverterModal() {
+    // Inject styles only once
+    if (!document.getElementById('st-converter-styles')) {
+        const style = document.createElement('style');
+        style.id = 'st-converter-styles';
+        style.textContent = `
+            .converter-modal { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: var(--SmartThemeBlurTintColor, rgba(20,22,28,0.95)); border: 1px solid rgba(255,255,255,0.1); padding: 20px; z-index: 40000; border-radius: 8px; width: 400px; box-shadow: 0 10px 30px rgba(0,0,0,0.5); backdrop-filter: blur(10px); color: var(--SmartThemeBodyColor, #fff); }
+            .converter-modal h3 { margin-top: 0; color: var(--SmartThemeQuoteColor, #4a90e2); border-bottom: 1px solid rgba(255,255,255,0.1); padding-bottom: 10px; }
+            .converter-zone { border: 2px dashed rgba(255,255,255,0.2); padding: 20px; text-align: center; margin: 15px 0; border-radius: 5px; cursor: pointer; transition: 0.2s; }
+            .converter-zone:hover, .converter-zone.dragover { border-color: var(--SmartThemeQuoteColor, #4a90e2); background: rgba(255,255,255,0.05); }
+            .converter-zone.ready { border-color: #4caf50; border-style: solid; background: rgba(76,175,80,0.05); }
+            .converter-btn { background: var(--SmartThemeQuoteColor, #4a90e2); color: #fff; border: none; padding: 10px; width: 100%; border-radius: 5px; cursor: pointer; font-weight: bold; }
+            .converter-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+            .converter-close { position: absolute; right: 15px; top: 15px; cursor: pointer; opacity: 0.7; font-size: 18px; }
+            .converter-close:hover { opacity: 1; }
+        `;
+        document.head.appendChild(style);
+    }
+
+    // Modal UI
+    const modal = document.createElement('div');
+    modal.className = 'converter-modal';
+    modal.innerHTML = `
+        <div class="converter-close" onclick="this.parentElement.remove()">✖</div>
+        <h3>JSON to PNG Converter</h3>
+        <div class="converter-zone" id="conv-json-zone">📄 Click or Drop JSON<input type="file" id="conv-json" accept=".json" style="display:none"></div>
+        <div class="converter-zone" id="conv-png-zone">🖼️ Click or Drop Base PNG<input type="file" id="conv-png" accept="image/png" style="display:none"></div>
+        <button class="converter-btn" id="conv-btn" disabled>Generate Card</button>
+    `;
+    document.body.appendChild(modal);
+
+    let jsonFile = null, pngFile = null;
+    
+    const setupZone = (zoneId, inputId, type) => {
+        const zone = modal.querySelector('#'+zoneId);
+        const input = modal.querySelector('#'+inputId);
+        zone.onclick = () => input.click();
+        zone.ondragover = (e) => { e.preventDefault(); zone.classList.add('dragover'); };
+        zone.ondragleave = () => zone.classList.remove('dragover');
+        zone.ondrop = (e) => { e.preventDefault(); zone.classList.remove('dragover'); if(e.dataTransfer.files[0]) handle(e.dataTransfer.files[0]); };
+        input.onchange = (e) => { if(e.target.files[0]) handle(e.target.files[0]); };
+        
+        function handle(f) {
+            if(!f.name.toLowerCase().endsWith('.'+type)) return alert('Please select a '+type.toUpperCase()+' file.');
+            if(type === 'json') jsonFile = f; else pngFile = f;
+            zone.classList.add('ready'); zone.textContent = "✔️ " + f.name;
+            modal.querySelector('#conv-btn').disabled = !(jsonFile && pngFile);
+        }
+    };
+    
+    setupZone('conv-json-zone', 'conv-json', 'json');
+    setupZone('conv-png-zone', 'conv-png', 'png');
+
+    // CRC32 Generator
+    const crcTable = [];
+    for(let n=0; n<256; n++){ let c=n; for(let k=0; k<8; k++){ c = c&1 ? 0xedb88320^(c>>>1) : c>>>1; } crcTable[n]=c; }
+    const crc32 = (buf) => { let c=0^-1; for(let i=0; i<buf.length; i++) c = crcTable[(c^buf[i])&0xff]^(c>>>8); return (c^-1)>>>0; };
+
+    modal.querySelector('#conv-btn').onclick = async function() {
+        this.textContent = "Processing..."; this.disabled = true;
+        try {
+            const jText = await jsonFile.text(); const iBuf = await pngFile.arrayBuffer();
+            let cData = JSON.parse(jText);
+            
+            // Encode base64 properly
+            const u8 = new TextEncoder().encode(jText);
+            let bin = ""; for(let i=0; i<u8.length; i+=8192) bin += String.fromCharCode.apply(null, u8.subarray(i, i+8192));
+            const b64 = btoa(bin);
+
+            // Build tEXt chunk
+            const txt = new TextEncoder().encode("chara\0" + b64);
+            const typ = new TextEncoder().encode("tEXt");
+            const len = new Uint8Array(4); new DataView(len.buffer).setUint32(0, txt.length, false);
+            const dat = new Uint8Array(4+txt.length); dat.set(typ,0); dat.set(txt,4);
+            const crc = new Uint8Array(4); new DataView(crc.buffer).setUint32(0, crc32(dat), false);
+            
+            const chunk = new Uint8Array(8+txt.length+4);
+            chunk.set(len,0); chunk.set(typ,4); chunk.set(txt,8); chunk.set(crc,8+txt.length);
+
+            // Assemble PNG
+            const orig = new Uint8Array(iBuf);
+            if(orig[0]!==137 || orig[1]!==80 || orig[2]!==78 || orig[3]!==71) throw new Error("Not a valid PNG image");
+            const final = new Uint8Array(33 + chunk.length + (orig.length-33));
+            final.set(orig.slice(0,33), 0); final.set(chunk, 33); final.set(orig.slice(33), 33+chunk.length);
+
+            // Download
+            const a = document.createElement('a'); a.href = URL.createObjectURL(new Blob([final], {type: 'image/png'}));
+            let name = cData.name || (cData.data && cData.data.name) || "character";
+            a.download = name.replace(/[^a-z0-9]/gi, '_').toLowerCase() + '_card.png';
+            document.body.appendChild(a); a.click(); document.body.removeChild(a);
+            
+            this.textContent = "✔️ Card Generated!"; setTimeout(() => { modal.remove(); }, 1500);
+        } catch(e) { alert("Error: " + e.message); this.textContent = "Generate Card"; this.disabled = false; }
+    }
+}


### PR DESCRIPTION
Hey there! I noticed many users asking for an easy way to convert `.json` character files into `.png` cards directly, without relying on third-party websites like charactercardconverter.com.

I've added a native JSON to PNG converter right into the launcher dropdown. This allows users to easily convert JSON files to ST compatible cards directly in the UI without relying on external websites, completely offline. The modal inherits the SmartTheme variables to blend in seamlessly with ST.

Thanks for the great extension!