### PR TITLE
Add CharaVault provider; optional gateway base URL for ChubAI/CharacterTavern

### DIFF
--- a/app/library.html
+++ b/app/library.html
@@ -2116,7 +2116,7 @@ https://jannyai.com/characters/uuid_slug
                                         </div>
                                     </div>
                                     <div class="settings-row">
-                                        <span class="settings-hint">Optional. Leave Base URL empty for direct chub.ai access. When set, the proxy is expected to expose <code>/v1/chub</code>, <code>/v1/chub-gw</code>, and <code>/v1/chub-av/avatars/</code>.</span>
+                                        <span class="settings-hint">Optional. Leave Base URL empty for direct chub.ai access. When set, the proxy is expected to expose <code>/v1/chub</code>, <code>/v1/chub-gw</code>, and <code>/v1/chub-av/avatars/</code>. A reference implementation is available at <a href="https://github.com/AdamsGH/charlib-proxy" target="_blank" rel="noopener">AdamsGH/charlib-proxy</a>.</span>
                                     </div>
                                     <details class="settings-advanced">
                                         <summary>Advanced: per-host overrides</summary>
@@ -2208,7 +2208,7 @@ https://jannyai.com/characters/uuid_slug
                                         </div>
                                     </div>
                                     <div class="settings-row">
-                                        <span class="settings-hint">Optional. Only fill these if you proxy CharaVault through a self-hosted gateway. Leave both empty for direct access.</span>
+                                        <span class="settings-hint">Optional. Only fill these if you proxy CharaVault through a self-hosted gateway. Leave both empty for direct access. A reference implementation is available at <a href="https://github.com/AdamsGH/charlib-proxy" target="_blank" rel="noopener">AdamsGH/charlib-proxy</a>.</span>
                                     </div>
                                 </div>
                                 <div class="settings-group">
@@ -2345,7 +2345,7 @@ https://jannyai.com/characters/uuid_slug
                                         </div>
                                     </div>
                                     <div class="settings-row">
-                                        <span class="settings-hint">Optional. Leave Base URL empty for direct character-tavern.com access. When set, the proxy is expected to expose <code>/v1/ct</code>, <code>/v1/ct-site</code>, and <code>/v1/ct-cdn</code>.</span>
+                                        <span class="settings-hint">Optional. Leave Base URL empty for direct character-tavern.com access. When set, the proxy is expected to expose <code>/v1/ct</code>, <code>/v1/ct-site</code>, and <code>/v1/ct-cdn</code>. A reference implementation is available at <a href="https://github.com/AdamsGH/charlib-proxy" target="_blank" rel="noopener">AdamsGH/charlib-proxy</a>.</span>
                                     </div>
                                     <details class="settings-advanced">
                                         <summary>Advanced: per-host overrides</summary>

--- a/app/library.html
+++ b/app/library.html
@@ -2138,6 +2138,62 @@ https://jannyai.com/characters/uuid_slug
                             </div>
                         </details>
 
+                        <!-- CharaVault provider settings -->
+                        <details class="settings-provider-section" id="settingsCharavaultSection">
+                            <summary>
+                                <i class="fa-solid fa-vault provider-icon"></i> CharaVault
+                                <i class="fa-solid fa-chevron-right provider-chevron"></i>
+                            </summary>
+                            <div class="settings-provider-body">
+                                <div class="settings-group">
+                                    <div class="settings-group-title"><i class="fa-solid fa-network-wired"></i> Gateway (optional)</div>
+                                    <div class="settings-row">
+                                        <label for="settingsCharavaultGatewayUrl">Gateway URL:</label>
+                                        <div class="settings-input-group">
+                                            <input type="text" id="settingsCharavaultGatewayUrl" placeholder="Leave empty for direct charavault.net access">
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <label for="settingsCharavaultGatewayKey">Gateway Key:</label>
+                                        <div class="settings-input-group">
+                                            <input type="password" id="settingsCharavaultGatewayKey" placeholder="Bearer token" autocomplete="new-password" data-sensitive="true">
+                                            <button id="toggleCharavaultGatewayKeyVisibility" class="glass-btn icon-only" title="Show/Hide">
+                                                <i class="fa-solid fa-eye"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <span class="settings-hint">Optional. Only fill these if you proxy CharaVault through a self-hosted gateway. Leave both empty for direct access.</span>
+                                    </div>
+                                </div>
+                                <div class="settings-group">
+                                    <div class="settings-group-title"><i class="fa-solid fa-key"></i> Authentication</div>
+                                    <div class="settings-row">
+                                        <label for="settingsCharavaultAppPassword">App Password:</label>
+                                        <div class="settings-input-group">
+                                            <input type="password" id="settingsCharavaultAppPassword" placeholder="cv_..." autocomplete="new-password" data-sensitive="true">
+                                            <button id="toggleCharavaultAppPasswordVisibility" class="glass-btn icon-only" title="Show/Hide">
+                                                <i class="fa-solid fa-eye"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <span class="settings-hint">Optional. CharaVault app password (cv_...) for higher rate limits and downloads. Generate one at <a href="https://charavault.net/account/app-passwords" target="_blank" rel="noopener">charavault.net</a>.</span>
+                                    </div>
+                                </div>
+                                <div class="settings-group">
+                                    <div class="settings-group-title"><i class="fa-solid fa-ban"></i> Exclude Tags</div>
+                                    <div class="settings-row">
+                                        <div class="provider-exclude-tags-container">
+                                            <div class="provider-exclude-tags-pills" id="charavaultExcludeTagsPills"></div>
+                                            <input type="text" class="glass-input provider-exclude-tags-input" id="charavaultExcludeTagsInput" placeholder="Type a tag and press Enter" autocomplete="off">
+                                        </div>
+                                        <span class="settings-hint">Tags entered here are always excluded from CharaVault browse results.</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </details>
+
                         <!-- Pygmalion provider settings -->
                         <details class="settings-provider-section" id="settingsPygmalionSection">
                             <summary>

--- a/app/library.html
+++ b/app/library.html
@@ -2099,6 +2099,51 @@ https://jannyai.com/characters/uuid_slug
                             </summary>
                             <div class="settings-provider-body">
                                 <div class="settings-group">
+                                    <div class="settings-group-title"><i class="fa-solid fa-network-wired"></i> Gateway (optional)</div>
+                                    <div class="settings-row">
+                                        <label for="settingsChubGatewayBaseUrl">Base URL:</label>
+                                        <div class="settings-input-group">
+                                            <input type="text" id="settingsChubGatewayBaseUrl" placeholder="https://your-proxy.example.com">
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <label for="settingsChubGatewayKey">Bearer Key:</label>
+                                        <div class="settings-input-group">
+                                            <input type="password" id="settingsChubGatewayKey" placeholder="Bearer token" autocomplete="new-password" data-sensitive="true">
+                                            <button id="toggleChubGatewayKeyVisibility" class="glass-btn icon-only" title="Show/Hide">
+                                                <i class="fa-solid fa-eye"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <span class="settings-hint">Optional. Leave Base URL empty for direct chub.ai access. When set, the proxy is expected to expose <code>/v1/chub</code>, <code>/v1/chub-gw</code>, and <code>/v1/chub-av/avatars/</code>.</span>
+                                    </div>
+                                    <details class="settings-advanced">
+                                        <summary>Advanced: per-host overrides</summary>
+                                        <div class="settings-row">
+                                            <label for="settingsChubGatewayApiUrl">API:</label>
+                                            <div class="settings-input-group">
+                                                <input type="text" id="settingsChubGatewayApiUrl" placeholder="overrides Base URL + /v1/chub">
+                                            </div>
+                                        </div>
+                                        <div class="settings-row">
+                                            <label for="settingsChubGatewayGatewayUrl">Gateway:</label>
+                                            <div class="settings-input-group">
+                                                <input type="text" id="settingsChubGatewayGatewayUrl" placeholder="overrides Base URL + /v1/chub-gw">
+                                            </div>
+                                        </div>
+                                        <div class="settings-row">
+                                            <label for="settingsChubGatewayAvatarUrl">Avatar Base:</label>
+                                            <div class="settings-input-group">
+                                                <input type="text" id="settingsChubGatewayAvatarUrl" placeholder="overrides Base URL + /v1/chub-av/avatars/">
+                                            </div>
+                                        </div>
+                                        <div class="settings-row">
+                                            <span class="settings-hint">Each field, when set, replaces the corresponding host directly. Avatar base must end with a slash.</span>
+                                        </div>
+                                    </details>
+                                </div>
+                                <div class="settings-group">
                                     <div class="settings-group-title"><i class="fa-solid fa-key"></i> Authentication</div>
                                     <div class="settings-row">
                                         <label for="settingsChubToken">URQL Token:</label>
@@ -2283,6 +2328,51 @@ https://jannyai.com/characters/uuid_slug
                                     </div>
                                 </div>
                                 <div class="settings-group" id="ctSettingsFields">
+                                    <div class="settings-group-title"><i class="fa-solid fa-network-wired"></i> Gateway (optional)</div>
+                                    <div class="settings-row">
+                                        <label for="settingsChartavernGatewayBaseUrl">Base URL:</label>
+                                        <div class="settings-input-group">
+                                            <input type="text" id="settingsChartavernGatewayBaseUrl" placeholder="https://your-proxy.example.com">
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <label for="settingsChartavernGatewayKey">Bearer Key:</label>
+                                        <div class="settings-input-group">
+                                            <input type="password" id="settingsChartavernGatewayKey" placeholder="Bearer token" autocomplete="new-password" data-sensitive="true">
+                                            <button id="toggleChartavernGatewayKeyVisibility" class="glass-btn icon-only" title="Show/Hide">
+                                                <i class="fa-solid fa-eye"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <span class="settings-hint">Optional. Leave Base URL empty for direct character-tavern.com access. When set, the proxy is expected to expose <code>/v1/ct</code>, <code>/v1/ct-site</code>, and <code>/v1/ct-cdn</code>.</span>
+                                    </div>
+                                    <details class="settings-advanced">
+                                        <summary>Advanced: per-host overrides</summary>
+                                        <div class="settings-row">
+                                            <label for="settingsChartavernGatewayApiUrl">API:</label>
+                                            <div class="settings-input-group">
+                                                <input type="text" id="settingsChartavernGatewayApiUrl" placeholder="overrides Base URL + /v1/ct">
+                                            </div>
+                                        </div>
+                                        <div class="settings-row">
+                                            <label for="settingsChartavernGatewaySiteUrl">Site:</label>
+                                            <div class="settings-input-group">
+                                                <input type="text" id="settingsChartavernGatewaySiteUrl" placeholder="overrides Base URL + /v1/ct-site">
+                                            </div>
+                                        </div>
+                                        <div class="settings-row">
+                                            <label for="settingsChartavernGatewayCdnUrl">Cards CDN:</label>
+                                            <div class="settings-input-group">
+                                                <input type="text" id="settingsChartavernGatewayCdnUrl" placeholder="overrides Base URL + /v1/ct-cdn">
+                                            </div>
+                                        </div>
+                                        <div class="settings-row">
+                                            <span class="settings-hint">Each field, when set, replaces the corresponding host directly.</span>
+                                        </div>
+                                    </details>
+                                </div>
+                                <div class="settings-group">
                                     <div class="settings-group-title"><i class="fa-solid fa-cookie-bite"></i> Session Cookies</div>
                                     <div class="settings-row">
                                         <label for="settingsCtCookie">Cookie String:</label>

--- a/app/library.js
+++ b/app/library.js
@@ -460,6 +460,16 @@ const DEFAULT_SETTINGS = {
     charavaultAppPassword: null,
     charavaultGatewayUrl: null,
     charavaultGatewayKey: null,
+    chubGatewayBaseUrl: null,
+    chubGatewayApiUrl: null,
+    chubGatewayGatewayUrl: null,
+    chubGatewayAvatarUrl: null,
+    chubGatewayKey: null,
+    chartavernGatewayBaseUrl: null,
+    chartavernGatewayApiUrl: null,
+    chartavernGatewaySiteUrl: null,
+    chartavernGatewayCdnUrl: null,
+    chartavernGatewayKey: null,
     civitaiApiKey: null,
 
     // ---- NSFW Toggles ----
@@ -991,6 +1001,18 @@ function setupSettingsModal() {
     const charavaultGatewayUrlInput = document.getElementById('settingsCharavaultGatewayUrl');
     const charavaultGatewayKeyInput = document.getElementById('settingsCharavaultGatewayKey');
     const toggleCharavaultGatewayKeyVisibility = document.getElementById('toggleCharavaultGatewayKeyVisibility');
+    const chubGatewayBaseUrlInput = document.getElementById('settingsChubGatewayBaseUrl');
+    const chubGatewayApiUrlInput = document.getElementById('settingsChubGatewayApiUrl');
+    const chubGatewayGatewayUrlInput = document.getElementById('settingsChubGatewayGatewayUrl');
+    const chubGatewayAvatarUrlInput = document.getElementById('settingsChubGatewayAvatarUrl');
+    const chubGatewayKeyInput = document.getElementById('settingsChubGatewayKey');
+    const toggleChubGatewayKeyVisibility = document.getElementById('toggleChubGatewayKeyVisibility');
+    const chartavernGatewayBaseUrlInput = document.getElementById('settingsChartavernGatewayBaseUrl');
+    const chartavernGatewayApiUrlInput = document.getElementById('settingsChartavernGatewayApiUrl');
+    const chartavernGatewaySiteUrlInput = document.getElementById('settingsChartavernGatewaySiteUrl');
+    const chartavernGatewayCdnUrlInput = document.getElementById('settingsChartavernGatewayCdnUrl');
+    const chartavernGatewayKeyInput = document.getElementById('settingsChartavernGatewayKey');
+    const toggleChartavernGatewayKeyVisibility = document.getElementById('toggleChartavernGatewayKeyVisibility');
     const wyvernEmailInput = document.getElementById('settingsWyvernEmail');
     const wyvernPasswordInput = document.getElementById('settingsWyvernPassword');
     const wyvernRememberCredsCheckbox = document.getElementById('settingsWyvernRememberCredentials');
@@ -1540,6 +1562,16 @@ function setupSettingsModal() {
         if (charavaultAppPasswordInput) charavaultAppPasswordInput.value = getSetting('charavaultAppPassword') || '';
         if (charavaultGatewayUrlInput) charavaultGatewayUrlInput.value = getSetting('charavaultGatewayUrl') || '';
         if (charavaultGatewayKeyInput) charavaultGatewayKeyInput.value = getSetting('charavaultGatewayKey') || '';
+        if (chubGatewayBaseUrlInput) chubGatewayBaseUrlInput.value = getSetting('chubGatewayBaseUrl') || '';
+        if (chubGatewayApiUrlInput) chubGatewayApiUrlInput.value = getSetting('chubGatewayApiUrl') || '';
+        if (chubGatewayGatewayUrlInput) chubGatewayGatewayUrlInput.value = getSetting('chubGatewayGatewayUrl') || '';
+        if (chubGatewayAvatarUrlInput) chubGatewayAvatarUrlInput.value = getSetting('chubGatewayAvatarUrl') || '';
+        if (chubGatewayKeyInput) chubGatewayKeyInput.value = getSetting('chubGatewayKey') || '';
+        if (chartavernGatewayBaseUrlInput) chartavernGatewayBaseUrlInput.value = getSetting('chartavernGatewayBaseUrl') || '';
+        if (chartavernGatewayApiUrlInput) chartavernGatewayApiUrlInput.value = getSetting('chartavernGatewayApiUrl') || '';
+        if (chartavernGatewaySiteUrlInput) chartavernGatewaySiteUrlInput.value = getSetting('chartavernGatewaySiteUrl') || '';
+        if (chartavernGatewayCdnUrlInput) chartavernGatewayCdnUrlInput.value = getSetting('chartavernGatewayCdnUrl') || '';
+        if (chartavernGatewayKeyInput) chartavernGatewayKeyInput.value = getSetting('chartavernGatewayKey') || '';
         if (wyvernEmailInput) wyvernEmailInput.value = getSetting('wyvernEmail') || '';
         if (wyvernPasswordInput) wyvernPasswordInput.value = getSetting('wyvernPassword') || '';
         if (wyvernRememberCredsCheckbox) wyvernRememberCredsCheckbox.checked = getSetting('wyvernRememberCredentials') || false;
@@ -1934,6 +1966,20 @@ function setupSettingsModal() {
             toggleCharavaultGatewayKeyVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
         };
     }
+    if (toggleChubGatewayKeyVisibility && chubGatewayKeyInput) {
+        toggleChubGatewayKeyVisibility.onclick = () => {
+            const isPassword = chubGatewayKeyInput.type === 'password';
+            chubGatewayKeyInput.type = isPassword ? 'text' : 'password';
+            toggleChubGatewayKeyVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
+        };
+    }
+    if (toggleChartavernGatewayKeyVisibility && chartavernGatewayKeyInput) {
+        toggleChartavernGatewayKeyVisibility.onclick = () => {
+            const isPassword = chartavernGatewayKeyInput.type === 'password';
+            chartavernGatewayKeyInput.type = isPassword ? 'text' : 'password';
+            toggleChartavernGatewayKeyVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
+        };
+    }
     
     // Slider value display
     const formatMinScore = (val) => parseInt(val) >= 120 ? 'Exact' : val;
@@ -2034,6 +2080,16 @@ function setupSettingsModal() {
             charavaultAppPassword: charavaultAppPasswordInput ? (charavaultAppPasswordInput.value?.trim() || null) : null,
             charavaultGatewayUrl: charavaultGatewayUrlInput ? (charavaultGatewayUrlInput.value?.trim() || null) : null,
             charavaultGatewayKey: charavaultGatewayKeyInput ? (charavaultGatewayKeyInput.value?.trim() || null) : null,
+            chubGatewayBaseUrl: chubGatewayBaseUrlInput ? (chubGatewayBaseUrlInput.value?.trim() || null) : null,
+            chubGatewayApiUrl: chubGatewayApiUrlInput ? (chubGatewayApiUrlInput.value?.trim() || null) : null,
+            chubGatewayGatewayUrl: chubGatewayGatewayUrlInput ? (chubGatewayGatewayUrlInput.value?.trim() || null) : null,
+            chubGatewayAvatarUrl: chubGatewayAvatarUrlInput ? (chubGatewayAvatarUrlInput.value?.trim() || null) : null,
+            chubGatewayKey: chubGatewayKeyInput ? (chubGatewayKeyInput.value?.trim() || null) : null,
+            chartavernGatewayBaseUrl: chartavernGatewayBaseUrlInput ? (chartavernGatewayBaseUrlInput.value?.trim() || null) : null,
+            chartavernGatewayApiUrl: chartavernGatewayApiUrlInput ? (chartavernGatewayApiUrlInput.value?.trim() || null) : null,
+            chartavernGatewaySiteUrl: chartavernGatewaySiteUrlInput ? (chartavernGatewaySiteUrlInput.value?.trim() || null) : null,
+            chartavernGatewayCdnUrl: chartavernGatewayCdnUrlInput ? (chartavernGatewayCdnUrlInput.value?.trim() || null) : null,
+            chartavernGatewayKey: chartavernGatewayKeyInput ? (chartavernGatewayKeyInput.value?.trim() || null) : null,
             wyvernEmail: wyvernEmailInput ? (wyvernEmailInput.value || null) : null,
             wyvernPassword: wyvernPasswordInput ? (wyvernPasswordInput.value || null) : null,
             wyvernRememberCredentials: wyvernRememberCredsCheckbox ? wyvernRememberCredsCheckbox.checked : false,
@@ -2201,6 +2257,16 @@ function setupSettingsModal() {
         if (charavaultAppPasswordInput) charavaultAppPasswordInput.value = '';
         if (charavaultGatewayUrlInput) charavaultGatewayUrlInput.value = '';
         if (charavaultGatewayKeyInput) charavaultGatewayKeyInput.value = '';
+        if (chubGatewayBaseUrlInput) chubGatewayBaseUrlInput.value = '';
+        if (chubGatewayApiUrlInput) chubGatewayApiUrlInput.value = '';
+        if (chubGatewayGatewayUrlInput) chubGatewayGatewayUrlInput.value = '';
+        if (chubGatewayAvatarUrlInput) chubGatewayAvatarUrlInput.value = '';
+        if (chubGatewayKeyInput) chubGatewayKeyInput.value = '';
+        if (chartavernGatewayBaseUrlInput) chartavernGatewayBaseUrlInput.value = '';
+        if (chartavernGatewayApiUrlInput) chartavernGatewayApiUrlInput.value = '';
+        if (chartavernGatewaySiteUrlInput) chartavernGatewaySiteUrlInput.value = '';
+        if (chartavernGatewayCdnUrlInput) chartavernGatewayCdnUrlInput.value = '';
+        if (chartavernGatewayKeyInput) chartavernGatewayKeyInput.value = '';
         if (wyvernEmailInput) wyvernEmailInput.value = '';
         if (wyvernPasswordInput) wyvernPasswordInput.value = '';
         if (wyvernRememberCredsCheckbox) wyvernRememberCredsCheckbox.checked = false;
@@ -2292,6 +2358,16 @@ function setupSettingsModal() {
             charavaultAppPassword: getSetting('charavaultAppPassword') || null,
             charavaultGatewayUrl: getSetting('charavaultGatewayUrl') || null,
             charavaultGatewayKey: getSetting('charavaultGatewayKey') || null,
+            chubGatewayBaseUrl: getSetting('chubGatewayBaseUrl') || null,
+            chubGatewayApiUrl: getSetting('chubGatewayApiUrl') || null,
+            chubGatewayGatewayUrl: getSetting('chubGatewayGatewayUrl') || null,
+            chubGatewayAvatarUrl: getSetting('chubGatewayAvatarUrl') || null,
+            chubGatewayKey: getSetting('chubGatewayKey') || null,
+            chartavernGatewayBaseUrl: getSetting('chartavernGatewayBaseUrl') || null,
+            chartavernGatewayApiUrl: getSetting('chartavernGatewayApiUrl') || null,
+            chartavernGatewaySiteUrl: getSetting('chartavernGatewaySiteUrl') || null,
+            chartavernGatewayCdnUrl: getSetting('chartavernGatewayCdnUrl') || null,
+            chartavernGatewayKey: getSetting('chartavernGatewayKey') || null,
         });
         
         const searchName = document.getElementById('searchName');

--- a/app/library.js
+++ b/app/library.js
@@ -457,6 +457,9 @@ const DEFAULT_SETTINGS = {
     datacatReextractOnUpdate: false,
     datacatFlareSolverrUrl: '',
     ctCookie: null,
+    charavaultAppPassword: null,
+    charavaultGatewayUrl: null,
+    charavaultGatewayKey: null,
     civitaiApiKey: null,
 
     // ---- NSFW Toggles ----
@@ -983,6 +986,11 @@ function setupSettingsModal() {
     const ctCookieInput = document.getElementById('settingsCtCookie');
     const ctPluginBanner = document.getElementById('ctPluginBanner');
     const ctSettingsFields = document.getElementById('ctSettingsFields');
+    const charavaultAppPasswordInput = document.getElementById('settingsCharavaultAppPassword');
+    const toggleCharavaultAppPasswordVisibility = document.getElementById('toggleCharavaultAppPasswordVisibility');
+    const charavaultGatewayUrlInput = document.getElementById('settingsCharavaultGatewayUrl');
+    const charavaultGatewayKeyInput = document.getElementById('settingsCharavaultGatewayKey');
+    const toggleCharavaultGatewayKeyVisibility = document.getElementById('toggleCharavaultGatewayKeyVisibility');
     const wyvernEmailInput = document.getElementById('settingsWyvernEmail');
     const wyvernPasswordInput = document.getElementById('settingsWyvernPassword');
     const wyvernRememberCredsCheckbox = document.getElementById('settingsWyvernRememberCredentials');
@@ -1467,6 +1475,7 @@ function setupSettingsModal() {
         { id: 'chartavern', inputId: 'ctExcludeTagsInput', pillsId: 'ctExcludeTagsPills' },
         { id: 'wyvern', inputId: 'wyvernExcludeTagsInput', pillsId: 'wyvernExcludeTagsPills' },
         { id: 'datacat', inputId: 'datacatExcludeTagsInput', pillsId: 'datacatExcludeTagsPills' },
+        { id: 'charavault', inputId: 'charavaultExcludeTagsInput', pillsId: 'charavaultExcludeTagsPills' },
     ];
 
     function renderExcludeTagPills(providerId, pillsId) {
@@ -1528,6 +1537,9 @@ function setupSettingsModal() {
         if (pygmalionPasswordInput) pygmalionPasswordInput.value = getSetting('pygmalionPassword') || '';
         if (pygmalionRememberCredsCheckbox) pygmalionRememberCredsCheckbox.checked = getSetting('pygmalionRememberCredentials') || false;
         if (ctCookieInput) ctCookieInput.value = getSetting('ctCookie') || '';
+        if (charavaultAppPasswordInput) charavaultAppPasswordInput.value = getSetting('charavaultAppPassword') || '';
+        if (charavaultGatewayUrlInput) charavaultGatewayUrlInput.value = getSetting('charavaultGatewayUrl') || '';
+        if (charavaultGatewayKeyInput) charavaultGatewayKeyInput.value = getSetting('charavaultGatewayKey') || '';
         if (wyvernEmailInput) wyvernEmailInput.value = getSetting('wyvernEmail') || '';
         if (wyvernPasswordInput) wyvernPasswordInput.value = getSetting('wyvernPassword') || '';
         if (wyvernRememberCredsCheckbox) wyvernRememberCredsCheckbox.checked = getSetting('wyvernRememberCredentials') || false;
@@ -1907,6 +1919,21 @@ function setupSettingsModal() {
             toggleDatacatTokenVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
         };
     }
+
+    if (toggleCharavaultAppPasswordVisibility && charavaultAppPasswordInput) {
+        toggleCharavaultAppPasswordVisibility.onclick = () => {
+            const isPassword = charavaultAppPasswordInput.type === 'password';
+            charavaultAppPasswordInput.type = isPassword ? 'text' : 'password';
+            toggleCharavaultAppPasswordVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
+        };
+    }
+    if (toggleCharavaultGatewayKeyVisibility && charavaultGatewayKeyInput) {
+        toggleCharavaultGatewayKeyVisibility.onclick = () => {
+            const isPassword = charavaultGatewayKeyInput.type === 'password';
+            charavaultGatewayKeyInput.type = isPassword ? 'text' : 'password';
+            toggleCharavaultGatewayKeyVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
+        };
+    }
     
     // Slider value display
     const formatMinScore = (val) => parseInt(val) >= 120 ? 'Exact' : val;
@@ -2004,6 +2031,9 @@ function setupSettingsModal() {
             pygmalionPassword: pygmalionPasswordInput ? (pygmalionPasswordInput.value || null) : null,
             pygmalionRememberCredentials: pygmalionRememberCredsCheckbox ? pygmalionRememberCredsCheckbox.checked : false,
             ctCookie: ctCookieInput ? (ctCookieInput.value?.trim() || null) : null,
+            charavaultAppPassword: charavaultAppPasswordInput ? (charavaultAppPasswordInput.value?.trim() || null) : null,
+            charavaultGatewayUrl: charavaultGatewayUrlInput ? (charavaultGatewayUrlInput.value?.trim() || null) : null,
+            charavaultGatewayKey: charavaultGatewayKeyInput ? (charavaultGatewayKeyInput.value?.trim() || null) : null,
             wyvernEmail: wyvernEmailInput ? (wyvernEmailInput.value || null) : null,
             wyvernPassword: wyvernPasswordInput ? (wyvernPasswordInput.value || null) : null,
             wyvernRememberCredentials: wyvernRememberCredsCheckbox ? wyvernRememberCredsCheckbox.checked : false,
@@ -2168,6 +2198,9 @@ function setupSettingsModal() {
         if (pygmalionPasswordInput) pygmalionPasswordInput.value = '';
         if (pygmalionRememberCredsCheckbox) pygmalionRememberCredsCheckbox.checked = false;
         if (ctCookieInput) ctCookieInput.value = '';
+        if (charavaultAppPasswordInput) charavaultAppPasswordInput.value = '';
+        if (charavaultGatewayUrlInput) charavaultGatewayUrlInput.value = '';
+        if (charavaultGatewayKeyInput) charavaultGatewayKeyInput.value = '';
         if (wyvernEmailInput) wyvernEmailInput.value = '';
         if (wyvernPasswordInput) wyvernPasswordInput.value = '';
         if (wyvernRememberCredsCheckbox) wyvernRememberCredsCheckbox.checked = false;
@@ -2256,6 +2289,9 @@ function setupSettingsModal() {
             wyvernUid: preserveWyv ? getSetting('wyvernUid') : null,
             datacatToken: getSetting('datacatToken') || null,
             ctCookie: getSetting('ctCookie') || null,
+            charavaultAppPassword: getSetting('charavaultAppPassword') || null,
+            charavaultGatewayUrl: getSetting('charavaultGatewayUrl') || null,
+            charavaultGatewayKey: getSetting('charavaultGatewayKey') || null,
         });
         
         const searchName = document.getElementById('searchName');

--- a/modules/module-loader.js
+++ b/modules/module-loader.js
@@ -328,6 +328,7 @@ async function initModuleSystem() {
     // Providers - must be Tier 1 because ProviderRegistry is queried
     // during character grid rendering (link indicators, taglines, etc.)
     loadModuleCSS('./providers/browse-shared.css');
+    loadModuleCSS('./providers/charavault/charavault-browse.css');
     loadModuleCSS('./providers/chub/chub-browse.css');
     loadModuleCSS('./providers/chartavern/chartavern-browse.css');
     loadModuleCSS('./providers/pygmalion/pygmalion-browse.css');
@@ -341,6 +342,7 @@ async function initModuleSystem() {
             { name: 'pygmalion', load: () => import('./providers/pygmalion/pygmalion-provider.js') },
             { name: 'wyvern', load: () => import('./providers/wyvern/wyvern-provider.js') },
             { name: 'datacat', load: () => import('./providers/datacat/datacat-provider.js') },
+            { name: 'charavault', load: () => import('./providers/charavault/charavault-provider.js') },
         ];
         const results = await Promise.allSettled(providerImports.map(p => p.load()));
         for (let i = 0; i < results.length; i++) {

--- a/modules/providers/charavault/charavault-api.js
+++ b/modules/providers/charavault/charavault-api.js
@@ -1,0 +1,389 @@
+// CharaVault API utilities
+
+// ========================================
+// CONSTANTS & RUNTIME HELPERS
+// ========================================
+
+const CV_DEFAULT_API = 'https://charavault.net/api';
+const CV_DEFAULT_CDN = 'https://charavault.net';
+
+export function getCvApiBase() {
+    const gw = (_getSetting?.('charavaultGatewayUrl') || '').trim().replace(/\/+$/, '');
+    return gw || CV_DEFAULT_API;
+}
+
+export function getCvCdnBase() {
+    const gw = (_getSetting?.('charavaultGatewayCdnUrl') || '').trim().replace(/\/+$/, '');
+    return gw || CV_DEFAULT_CDN;
+}
+
+// ========================================
+// INITIALIZATION
+// ========================================
+
+let _getSetting = null;
+let _debugLog = null;
+
+/**
+ * Must be called once before any other export is used.
+ * @param {{ getSetting: Function, debugLog: Function }} deps
+ */
+export function initCvApi(deps) {
+    _getSetting = deps.getSetting;
+    _debugLog = deps.debugLog;
+}
+
+function debugLog(...args) {
+    _debugLog?.(...args);
+}
+
+// ========================================
+// HEADERS
+// ========================================
+
+export function getCvHeaders() {
+    const headers = { 'Accept': 'application/json' };
+    const gwKey = _getSetting?.('charavaultGatewayKey');
+    if (gwKey) headers['Authorization'] = `Bearer ${gwKey}`;
+    const appPw = _getSetting?.('charavaultAppPassword');
+    if (appPw) headers['X-App-Password'] = appPw;
+    return headers;
+}
+
+// ========================================
+// URL HELPERS
+// ========================================
+
+/**
+ * Build the thumbnail URL for a card via the cv-cdn route.
+ * CharaVault serves pre-rendered thumbnails at /cards/thumb/{folder}/{filename}.
+ * @param {string} folder
+ * @param {string} file
+ * @returns {string}
+ */
+export function cvThumbUrl(folder, file) {
+    return `${getCvCdnBase()}/cards/thumb/${encodeURIComponent(folder)}/${encodeURIComponent(file)}`;
+}
+
+/**
+ * Build the full PNG download URL for a card via the cv API route.
+ * @param {string} folder
+ * @param {string} file
+ * @returns {string}
+ */
+export function cvDownloadUrl(folder, file) {
+    return `${getCvApiBase()}/cards/download/${encodeURIComponent(folder)}/${encodeURIComponent(file)}`;
+}
+
+/**
+ * Build a stable provider fullPath from folder + file.
+ * Used as the canonical identifier stored in card extensions.
+ * @param {string} folder
+ * @param {string} file
+ * @returns {string}  e.g. "cards/Adley_5412114.png"
+ */
+export function cvFullPath(folder, file) {
+    return `${folder}/${file}`;
+}
+
+/**
+ * Split a fullPath back into { folder, file }.
+ * @param {string} fullPath
+ * @returns {{ folder: string, file: string }}
+ */
+export function splitCvPath(fullPath) {
+    const idx = fullPath.indexOf('/');
+    if (idx < 0) return { folder: 'cards', file: fullPath };
+    return { folder: fullPath.slice(0, idx), file: fullPath.slice(idx + 1) };
+}
+
+// ========================================
+// METADATA CACHE
+// ========================================
+
+export const cvMetadataCache = new Map();
+const CV_METADATA_CACHE_MAX = 10;
+const CV_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+
+// ========================================
+// CARD LIST FETCH
+// ========================================
+
+/**
+ * Fetch a page of cards from the CharaVault browse API.
+ * @param {Object} params
+ * @param {string} [params.q]          - Search query
+ * @param {string} [params.tags]       - Comma-separated tag filter
+ * @param {string} [params.creator]    - Filter by creator username
+ * @param {boolean|null} [params.nsfw] - true = include NSFW only; false = SFW only; null = all (omit param)
+ * @param {boolean} [params.has_book]  - Filter to cards with lorebooks
+ * @param {string} [params.sort]       - Sort mode
+ * @param {number} [params.limit]      - Page size (default 48)
+ * @param {number} [params.offset]     - Page offset
+ * @returns {Promise<{total: number, results: Array}>}
+ */
+export async function fetchCvCards({
+    q = '',
+    tags = '',
+    creator = '',
+    nsfw = false,
+    has_book = false,
+    sort = 'most_downloaded',
+    limit = 48,
+    offset = 0,
+} = {}) {
+    const p = new URLSearchParams();
+    if (q) p.set('q', q);
+    if (tags) p.set('tags', tags);
+    if (creator) p.set('creator', creator);
+    if (nsfw !== null && nsfw !== undefined) p.set('nsfw', String(nsfw));
+    if (has_book) p.set('has_book', 'true');
+    p.set('sort', sort);
+    p.set('limit', String(limit));
+    p.set('offset', String(offset));
+
+    const url = `${getCvApiBase()}/cards?${p}`;
+
+    const resp = await fetch(url, { headers: getCvHeaders() });
+    if (!resp.ok) throw new Error(`CharaVault API error: ${resp.status}`);
+    return await resp.json();
+}
+
+// ========================================
+// CARD DETAIL FETCH
+// ========================================
+
+/**
+ * Fetch full metadata for a single card (with LRU cache).
+ * Returns the card entry plus full_metadata containing the V2 card fields.
+ * @param {string} fullPath - e.g. "cards/Adley_5412114.png"
+ * @returns {Promise<Object|null>}
+ */
+export async function fetchCvCardDetail(fullPath) {
+    const cached = cvMetadataCache.get(fullPath);
+    if (cached && Date.now() - cached.time < CV_CACHE_TTL) {
+        debugLog('[CharaVault] Using cached metadata for:', fullPath);
+        return cached.value;
+    }
+
+    const { folder, file } = splitCvPath(fullPath);
+    const url = `${getCvApiBase()}/cards/${encodeURIComponent(folder)}/${encodeURIComponent(file)}`;
+
+    try {
+        const resp = await fetch(url, { headers: getCvHeaders() });
+        if (!resp.ok) {
+            return null;
+        }
+        const data = await resp.json();
+        const result = {
+            entry: data.entry || null,
+            fullMetadata: data.full_metadata || null,
+        };
+
+        while (cvMetadataCache.size >= CV_METADATA_CACHE_MAX) {
+            const firstKey = cvMetadataCache.keys().next().value;
+            cvMetadataCache.delete(firstKey);
+        }
+        cvMetadataCache.set(fullPath, { value: result, time: Date.now() });
+        return result;
+    } catch (e) {
+        debugLog('[CharaVault] fetchCvCardDetail:', e.message);
+        return null;
+    }
+}
+
+// ========================================
+// LIVE RATING FETCH (per-card)
+// ========================================
+
+/**
+ * Fetch live rating for a single card. Cheaper than full detail and used
+ * for the modal stat row.
+ * @param {string} fullPath
+ * @returns {Promise<{avg_rating:number, rating_count:number, user_rating:number|null}|null>}
+ */
+export async function fetchCvRating(fullPath) {
+    const url = `${getCvApiBase()}/cards/rating?path=${encodeURIComponent(fullPath)}`;
+    try {
+        const resp = await fetch(url, { headers: getCvHeaders() });
+        if (!resp.ok) return null;
+        return await resp.json();
+    } catch (e) {
+        debugLog('[CharaVault] fetchCvRating error:', e.message);
+        return null;
+    }
+}
+
+// ========================================
+// LINKED LOREBOOKS (per-card)
+// ========================================
+
+/**
+ * Fetch lorebooks linked to a card. Returns { card_name, lorebooks: [...] }
+ * or null on error. Always returns gracefully on 404 / network failure.
+ * @param {string} fullPath
+ * @returns {Promise<{card_name:string, lorebooks:Array}|null>}
+ */
+export async function fetchCvLinkedLorebooks(fullPath) {
+    const { folder, file } = splitCvPath(fullPath);
+    const url = `${getCvApiBase()}/cards/${encodeURIComponent(folder)}/${encodeURIComponent(file)}/lorebooks`;
+    try {
+        const resp = await fetch(url, { headers: getCvHeaders() });
+        if (!resp.ok) return null;
+        return await resp.json();
+    } catch (e) {
+        debugLog('[CharaVault] fetchCvLinkedLorebooks error:', e.message);
+        return null;
+    }
+}
+
+// ========================================
+// SIMILAR CARDS (visual hash)
+// ========================================
+
+/**
+ * Fetch visually similar cards (image-hash based).
+ *
+ * IMPORTANT: the `path` query parameter is the **server-side absolute path**
+ * stored in entry.path (e.g. "/mnt/sde2/CharacterCards/..."), NOT our
+ * canonical folder/file fullPath. The public docs are misleading: the form
+ * "folder/file" gives 404 'Source card not found' for every card.
+ *
+ * The site UI also passes `threshold=20`. We mirror that.
+ *
+ * Returns an object so the caller can distinguish:
+ *   - { ok: true, results: [...] }                       success
+ *   - { ok: false, reason: 'no_path', results: [] }      caller passed no diskPath
+ *   - { ok: false, reason: 'no_hash', results: [] }      404 "Source card not found"
+ *   - { ok: false, reason: 'http', status, results: [] } any other non-2xx
+ *   - { ok: false, reason: 'error', error, results: [] } network failure
+ *
+ * @param {string} diskPath - absolute server-side path from entry.path
+ * @param {number} [limit=24]
+ * @param {number} [threshold=20]
+ * @returns {Promise<{ok:boolean, results:Array, reason?:string, status?:number, error?:string}>}
+ */
+export async function fetchCvSimilar(diskPath, threshold = 20) {
+    if (!diskPath) {
+        return { ok: false, reason: 'no_path', results: [] };
+    }
+    const p = new URLSearchParams({
+        path: diskPath,
+        threshold: String(threshold),
+    });
+    const url = `${getCvApiBase()}/cards/similar?${p}`;
+    try {
+        const resp = await fetch(url, { headers: getCvHeaders() });
+        if (resp.status === 404) {
+            return { ok: false, reason: 'no_hash', results: [] };
+        }
+        if (!resp.ok) {
+            return { ok: false, reason: 'http', status: resp.status, results: [] };
+        }
+        const data = await resp.json();
+        // Backend returns { source, similar_count, similar: [...] }.
+        // Older deployments may have used { results: [...] } - handle both.
+        const results = data.similar || data.results
+            || (Array.isArray(data) ? data : []);
+        return { ok: true, results };
+    } catch (e) {
+        debugLog('[CharaVault] fetchCvSimilar error:', e.message);
+        return { ok: false, reason: 'error', error: e.message, results: [] };
+    }
+}
+
+// ========================================
+// TAGS FETCH
+// ========================================
+
+/**
+ * Fetch popular tags from the public CV endpoint.
+ * Returns an array of [tagName, count] pairs.
+ * @returns {Promise<Array<[string, number]>>}
+ */
+export async function fetchCvTags() {
+    try {
+        const resp = await fetch(`${getCvApiBase()}/tags`, { headers: getCvHeaders() });
+        if (!resp.ok) return [];
+        const data = await resp.json();
+        return Array.isArray(data.tags) ? data.tags : [];
+    } catch (e) {
+        debugLog('[CharaVault] fetchCvTags:', e.message);
+        return [];
+    }
+}
+
+// ========================================
+// V2 CARD BUILDER
+// ========================================
+
+/**
+ * Build a V2 character card from a CharaVault card detail response.
+ *
+ * CharaVault's full_metadata.data is already V2-compatible:
+ *   data.description     -> V2 description  (character "personality" definition)
+ *   data.personality     -> V2 personality
+ *   data.first_mes       -> V2 first_mes
+ *   data.mes_example     -> V2 mes_example
+ *   data.creator_notes   -> V2 creator_notes
+ *   data.system_prompt   -> V2 system_prompt
+ *   data.post_history_instructions -> V2 post_history_instructions
+ *   data.alternate_greetings       -> V2 alternate_greetings
+ *   data.tags            -> V2 tags
+ *   data.creator         -> V2 creator
+ *
+ * Note: detail-API entry lacks `has_lorebook` (only the search-list entry
+ * carries it). Pass `searchEntry` (the original list-row) so we can
+ * preserve that flag in the embedded extension metadata.
+ *
+ * @param {Object} detail  - Object returned by fetchCvCardDetail()
+ * @param {string} fullPath - provider fullPath for the card
+ * @param {Object} [searchEntry] - the original search-list row, if available
+ * @returns {Object} V2-spec character card { spec, spec_version, data }
+ */
+export function buildCvCharacterCard(detail, fullPath, searchEntry = null) {
+    const entry = detail?.entry || {};
+    const metaData = detail?.fullMetadata?.data || {};
+
+    const tags = metaData.tags?.length ? metaData.tags : (entry.tags || []);
+    const name = metaData.name || entry.name || fullPath.split('/').pop().replace(/\.png$/i, '');
+    const creator = metaData.creator || entry.creator || '';
+
+    // has_lorebook lives only in the search-list entry, not in the detail
+    // entry. Prefer search row, fall back to detail just in case.
+    const hasLorebook = (searchEntry?.has_lorebook ?? entry.has_lorebook) || false;
+
+    return {
+        spec: 'chara_card_v2',
+        spec_version: '2.0',
+        data: {
+            name,
+            description: metaData.description || '',
+            personality: metaData.personality || '',
+            scenario: metaData.scenario || '',
+            first_mes: metaData.first_mes || '',
+            mes_example: metaData.mes_example || '',
+            creator_notes: metaData.creator_notes || '',
+            system_prompt: metaData.system_prompt || '',
+            post_history_instructions: metaData.post_history_instructions || '',
+            alternate_greetings: metaData.alternate_greetings || [],
+            tags,
+            creator,
+            character_version: metaData.character_version || '',
+            extensions: {
+                ...(metaData.extensions || {}),
+                charavault: {
+                    full_path: fullPath,
+                    content_hash: entry.content_hash || '',
+                    avg_rating: entry.avg_rating || 0,
+                    rating_count: entry.rating_count || 0,
+                    download_count: entry.download_count || 0,
+                    has_lorebook: hasLorebook,
+                    card_style: entry.card_style || null,
+                    recommended_tier: entry.recommended_tier ?? null,
+                    linkedAt: new Date().toISOString(),
+                },
+            },
+        },
+    };
+}

--- a/modules/providers/charavault/charavault-browse.css
+++ b/modules/providers/charavault/charavault-browse.css
@@ -1,0 +1,242 @@
+/* ============================================
+   CharaVault Browse CSS
+   Provider-specific overrides only.
+   Grid layout and card base styles live in browse-shared.css.
+   ============================================ */
+
+/* NSFW 3-state toggle: SFW only (default), NSFW only, Any */
+#cvNsfwToggle.nsfw-active {
+    background: rgba(231, 76, 60, 0.25);
+    border-color: rgba(231, 76, 60, 0.5);
+    color: #e74c3c;
+}
+
+#cvNsfwToggle.nsfw-any {
+    background: rgba(155, 89, 182, 0.22);
+    border-color: rgba(155, 89, 182, 0.5);
+    color: #c39bd3;
+}
+
+/* Lorebook badge on cards */
+.cv-badge-lorebook {
+    font-size: 0.7rem;
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: rgba(52, 152, 219, 0.3);
+    color: #5dade2;
+    border: 1px solid rgba(52, 152, 219, 0.4);
+}
+
+/* Tags dropdown filter layout */
+#cvTagsDropdown .browse-tags-list {
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+/* Feature filters */
+#cvFiltersDropdown {
+    width: 240px;
+}
+
+/* Creator banner */
+.cv-creator-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 14px;
+    background: rgba(var(--accent-rgb, 74, 144, 226), 0.08);
+    border: 1px solid rgba(var(--accent-rgb, 74, 144, 226), 0.2);
+    border-radius: 8px;
+    margin-bottom: 10px;
+    gap: 10px;
+}
+
+.cv-creator-banner.hidden {
+    display: none;
+}
+
+.cv-creator-banner-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--font-md);
+    color: var(--text-primary, #e0e0e0);
+}
+
+.cv-creator-banner-content i {
+    color: var(--accent, #4a90e2);
+}
+
+.cv-creator-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* Modal stat grid */
+.cv-modal-stats {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+}
+
+.cv-modal-stat {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--font-md);
+    color: var(--text-secondary, #aaa);
+}
+
+.cv-modal-stat i {
+    width: 14px;
+    text-align: center;
+    color: var(--accent, #4a90e2);
+}
+
+/* Token count display */
+.cv-token-count {
+    font-variant-numeric: tabular-nums;
+}
+
+.cv-modal-stat-sub {
+    margin-left: 4px;
+    font-size: 0.85em;
+    color: var(--text-secondary, #888);
+    font-variant-numeric: tabular-nums;
+}
+
+/* Recommended tier box (model class hint) */
+.cv-modal-tier {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    margin: 6px 0 12px;
+    padding: 8px 12px;
+    background: rgba(var(--accent-rgb, 74, 144, 226), 0.06);
+    border-left: 3px solid rgba(var(--accent-rgb, 74, 144, 226), 0.55);
+    border-radius: 4px;
+    font-size: var(--font-md);
+}
+
+.cv-modal-tier > i {
+    color: var(--accent, #4a90e2);
+    margin-top: 2px;
+}
+
+.cv-modal-tier-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    line-height: 1.35;
+}
+
+.cv-modal-tier-text strong {
+    color: var(--text-primary);
+}
+
+.cv-modal-tier-preset {
+    margin-top: 2px;
+    font-size: 0.85em;
+    color: var(--text-secondary, #888);
+    font-style: italic;
+}
+
+/* Linked lorebooks list inside preview modal */
+.cv-linked-books-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.cv-linked-book {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 4px;
+    font-size: var(--font-md);
+}
+
+.cv-linked-book i {
+    color: var(--accent, #4a90e2);
+    width: 14px;
+    text-align: center;
+}
+
+.cv-linked-book-title {
+    color: var(--text-primary, #e0e0e0);
+    flex: 1;
+}
+
+.cv-linked-book-meta {
+    color: var(--text-secondary, #888);
+    font-size: 0.85em;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Visually similar grid */
+.cv-similar-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 8px;
+}
+
+.cv-similar-card {
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+    border-radius: 4px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.03);
+    transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.cv-similar-card:hover {
+    background: rgba(var(--accent-rgb, 74, 144, 226), 0.12);
+    transform: translateY(-1px);
+}
+
+.cv-similar-card-thumb {
+    position: relative;
+}
+
+.cv-similar-card img {
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    display: block;
+}
+
+.cv-similar-card-score {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    padding: 2px 6px;
+    font-size: 0.75em;
+    font-weight: 600;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    border-radius: 3px;
+    font-variant-numeric: tabular-nums;
+}
+
+.cv-similar-card-name {
+    padding: 4px 6px 0;
+    font-size: 0.85em;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.cv-similar-card-creator {
+    padding: 0 6px 4px;
+    font-size: 0.75em;
+    color: var(--text-secondary, #888);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/modules/providers/charavault/charavault-browse.js
+++ b/modules/providers/charavault/charavault-browse.js
@@ -1,0 +1,1417 @@
+// CharaVaultBrowseView - CharaVault browse/search UI for the Online tab
+
+import { BrowseView } from '../browse-view.js';
+import CoreAPI from '../../core-api.js';
+import { IMG_PLACEHOLDER, formatNumber } from '../provider-utils.js';
+import {
+    cvThumbUrl,
+    cvFullPath,
+    fetchCvCards,
+    fetchCvCardDetail,
+    fetchCvTags,
+    fetchCvRating,
+    fetchCvLinkedLorebooks,
+    fetchCvSimilar,
+} from './charavault-api.js';
+
+// ========================================
+// CORE-API DESTRUCTURE
+// ========================================
+
+/* eslint-disable no-unused-vars */
+const {
+    onElement: on,
+    showElement: show,
+    hideElement: hide,
+    hideModal,
+    debugLog,
+    showToast,
+    escapeHtml,
+    safePurify,
+    formatRichText,
+    renderLoadingState,
+    getSetting,
+    debounce,
+    fetchCharacters,
+    fetchAndAddCharacter,
+    deleteCharacter,
+    checkCharacterForDuplicatesAsync,
+    showPreImportDuplicateWarning,
+    showImportSummaryModal,
+    getProviderExcludeTags,
+    renderCreatorNotesSecure,
+    cleanupCreatorNotesContainer,
+} = CoreAPI;
+/* eslint-enable no-unused-vars */
+
+const BROWSE_PURIFY_CONFIG = {
+    ALLOWED_TAGS: [
+        'p', 'br', 'hr', 'div', 'span', 'strong', 'b', 'em', 'i', 'u', 's', 'del',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'code', 'pre',
+        'ul', 'ol', 'li', 'a', 'img', 'center', 'font', 'style',
+        'table', 'thead', 'tbody', 'tr', 'th', 'td', 'details', 'summary'
+    ],
+    ALLOWED_ATTR: [
+        'href', 'src', 'alt', 'title', 'class', 'style', 'target', 'rel',
+        'width', 'height', 'loading', 'color', 'size', 'align'
+    ],
+    ALLOW_DATA_ATTR: false
+};
+
+// ========================================
+// STATE
+// ========================================
+
+let cvCharacters = [];
+let cvCurrentPage = 0;       // offset = cvCurrentPage * PAGE_SIZE
+let cvHasMore = true;
+let cvIsLoading = false;
+let cvLoadToken = 0;
+let cvCurrentSearch = '';
+let cvCurrentCreator = '';   // creator filter (author banner)
+let cvSortMode = 'most_downloaded';
+let cvNsfwMode = 'sfw';      // 'sfw' | 'nsfw' | 'any'
+let cvLorebookMode = 'any';  // 'any' | 'with' | 'without'
+let cvSelectedChar = null;
+let cvTagFilters = new Set();  // Set of tag names to include
+let cvGridRenderedCount = 0;
+
+const PAGE_SIZE = 48;
+
+// Popular tags cache
+let cvPopularTags = [];
+let cvTagsLoaded = false;
+
+// Module-scoped view reference (set in constructor for card-inline helpers)
+let view;
+
+// ========================================
+// HELPERS
+// ========================================
+
+function cvIsInLibrary(char) {
+    const fp = char.fullPath || '';
+    const name = (char.name || '').toLowerCase().trim();
+    const creator = (char.creator || '').toLowerCase().trim();
+    if (fp && view._lookup.byProviderId.has(fp.toLowerCase())) return true;
+    if (name && creator && view._lookup.byNameAndCreator.has(`${name}|${creator}`)) return true;
+    return false;
+}
+
+function cvIsPossibleMatch(char) {
+    if (cvIsInLibrary(char)) return false;
+    return view.isCharPossibleMatch(char.name || '', char.creator || '');
+}
+
+function markCvCardImported(fullPath) {
+    const grid = document.getElementById('cvGrid');
+    if (!grid || !fullPath) return;
+    const card = grid.querySelector(`[data-full-path="${CSS.escape(fullPath)}"]`);
+    if (!card) return;
+    card.classList.add('in-library');
+    card.classList.remove('possible-library');
+    let badgesEl = card.querySelector('.browse-feature-badges');
+    if (!badgesEl) {
+        const imgWrap = card.querySelector('.browse-card-image');
+        if (imgWrap) {
+            imgWrap.insertAdjacentHTML('beforeend', '<div class="browse-feature-badges"></div>');
+            badgesEl = imgWrap.querySelector('.browse-feature-badges');
+        }
+    }
+    if (badgesEl) {
+        badgesEl.querySelector('.possible-library')?.remove();
+        if (!badgesEl.querySelector('.in-library')) {
+            badgesEl.insertAdjacentHTML('afterbegin', '<span class="browse-feature-badge in-library" title="In Your Library"><i class="fa-solid fa-check"></i></span>');
+        }
+    }
+}
+
+// ========================================
+// BROWSE VIEW CLASS
+// ========================================
+
+class CharaVaultBrowseView extends BrowseView {
+
+    constructor(provider) {
+        super(provider);
+        this._preloadLimit = 72;
+        view = this;
+    }
+
+    _extractProviderIds(char, idSet) {
+        const cv = char.data?.extensions?.charavault;
+        if (cv?.full_path) idSet.add(cv.full_path.toLowerCase());
+    }
+
+    get previewModalId() { return 'cvCharModal'; }
+
+    _getImageGridIds() { return ['cvGrid']; }
+
+    closePreview() {
+        const notesEl = document.getElementById('cvCharCreatorNotes');
+        if (notesEl) cleanupCreatorNotesContainer?.(notesEl);
+        hideModal('cvCharModal');
+    }
+
+    canLoadMore() { return cvHasMore && !cvIsLoading; }
+
+    async loadMore() {
+        cvCurrentPage++;
+        await loadCvCharacters();
+    }
+
+    // ── Filter Bar ──────────────────────────────────────────
+
+    renderFilterBar() {
+        return `
+            <!-- Sort dropdown -->
+            <div class="browse-sort-container">
+                <select id="cvSortSelect" class="glass-select" title="Sort order">
+                    <option value="most_downloaded" selected>Most Downloaded</option>
+                    <option value="top_rated">Top Rated</option>
+                    <option value="newest">Newest</option>
+                    <option value="oldest">Oldest</option>
+                    <option value="name_asc">Name A-Z</option>
+                    <option value="name_desc">Name Z-A</option>
+                    <option value="token_count_desc">Most Tokens</option>
+                    <option value="token_count_asc">Fewest Tokens</option>
+                </select>
+            </div>
+
+            <!-- Tag filters dropdown -->
+            <div class="browse-tags-dropdown-container" style="position: relative;">
+                <button id="cvTagsBtn" class="glass-btn" title="Filter by tags">
+                    <i class="fa-solid fa-tags"></i> <span id="cvTagsBtnLabel">Tags</span>
+                </button>
+                <div id="cvTagsDropdown" class="dropdown-menu browse-tags-dropdown hidden">
+                    <div class="browse-tags-search-row">
+                        <input type="search" id="cvTagsSearchInput" placeholder="Search tags..." autocomplete="one-time-code">
+                        <button id="cvTagsClearBtn" class="glass-btn icon-only" title="Clear tag filters">
+                            <i class="fa-solid fa-rotate-left"></i>
+                        </button>
+                    </div>
+                    <div class="browse-tags-list" id="cvTagsList">
+                        <div class="browse-tags-loading"><i class="fa-solid fa-spinner fa-spin"></i> Loading tags...</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Feature filters -->
+            <div class="browse-more-filters" style="position: relative;">
+                <button id="cvFiltersBtn" class="glass-btn" title="Feature filters">
+                    <i class="fa-solid fa-sliders"></i> <span>Features</span>
+                </button>
+                <div id="cvFiltersDropdown" class="dropdown-menu browse-features-dropdown hidden">
+                    <div class="dropdown-section-title">Lorebook</div>
+                    <label class="filter-checkbox"><input type="radio" name="cvLorebookMode" value="any" checked> Any</label>
+                    <label class="filter-checkbox"><input type="radio" name="cvLorebookMode" value="with"> <i class="fa-solid fa-book"></i> Has lorebook</label>
+                    <label class="filter-checkbox"><input type="radio" name="cvLorebookMode" value="without"> <i class="fa-solid fa-book-skull"></i> No lorebook</label>
+                </div>
+            </div>
+
+            <!-- NSFW 3-state toggle -->
+            <button id="cvNsfwToggle" class="glass-btn nsfw-toggle" title="Cycle NSFW filter (SFW only / NSFW only / Any)">
+                <i class="fa-solid fa-shield-halved"></i> <span>SFW Only</span>
+            </button>
+
+            <!-- Refresh -->
+            <button id="refreshCvBtn" class="glass-btn icon-only" title="Refresh">
+                <i class="fa-solid fa-sync"></i>
+            </button>
+        `;
+    }
+
+    // ── Main View ───────────────────────────────────────────
+
+    renderView() {
+        return `
+            <div id="cvBrowseSection" class="browse-section">
+                <div class="browse-search-bar">
+                    <div class="browse-search-input-wrapper">
+                        <i class="fa-solid fa-search"></i>
+                        <input type="search" id="cvSearchInput" placeholder="Search CharaVault characters..." autocomplete="one-time-code">
+                        <button id="cvClearSearchBtn" class="browse-search-clear hidden" title="Clear search">
+                            <i class="fa-solid fa-xmark"></i>
+                        </button>
+                        <button id="cvSearchBtn" class="browse-search-submit">
+                            <i class="fa-solid fa-arrow-right"></i>
+                        </button>
+                    </div>
+                    <div class="browse-creator-search">
+                        <div class="browse-creator-search-wrapper">
+                            <i class="fa-solid fa-user"></i>
+                            <input type="search" id="cvCreatorSearchInput" placeholder="Filter by creator..." autocomplete="one-time-code">
+                            <button id="cvCreatorSearchBtn" class="browse-search-submit" title="Filter by creator">
+                                <i class="fa-solid fa-arrow-right"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Creator banner (shown when filtering by creator) -->
+                <div id="cvCreatorBanner" class="cv-creator-banner hidden">
+                    <div class="cv-creator-banner-content">
+                        <i class="fa-solid fa-user"></i>
+                        <span>Showing characters by <strong id="cvCreatorBannerName"></strong></span>
+                    </div>
+                    <div class="cv-creator-banner-actions">
+                        <button id="cvClearCreatorBtn" class="glass-btn icon-only" title="Clear creator filter">
+                            <i class="fa-solid fa-times"></i>
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Results grid -->
+                <div id="cvGrid" class="browse-grid"></div>
+
+                <!-- Load more -->
+                <div class="browse-load-more" id="cvLoadMore" style="display: none;">
+                    <button id="cvLoadMoreBtn" class="glass-btn">
+                        <i class="fa-solid fa-plus"></i> Load More
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    // ── Preview Modal ───────────────────────────────────────
+
+    renderModals() {
+        return `
+    <div id="cvCharModal" class="modal-overlay hidden">
+        <div class="modal-glass browse-char-modal">
+            <div class="modal-header">
+                <div class="browse-char-header-info">
+                    <img id="cvCharAvatar" src="" alt="" class="browse-char-avatar">
+                    <div>
+                        <h2 id="cvCharName">Character Name</h2>
+                        <p class="browse-char-meta">
+                            by <a id="cvCharCreator" href="#" title="Show all by this creator">Creator</a>
+                        </p>
+                    </div>
+                </div>
+                <div class="modal-controls">
+                    <a id="cvOpenInBrowserBtn" href="#" target="_blank" class="action-btn secondary" title="Open on CharaVault">
+                        <i class="fa-solid fa-external-link"></i> Open
+                    </a>
+                    <button id="cvDownloadBtn" class="action-btn primary" title="Import to SillyTavern">
+                        <i class="fa-solid fa-download"></i> Import
+                    </button>
+                    <button class="close-btn" id="cvCharClose">&times;</button>
+                </div>
+            </div>
+            <div class="browse-char-body">
+                <div class="cv-modal-stats">
+                    <div class="cv-modal-stat" title="Average rating / vote count">
+                        <i class="fa-solid fa-star"></i>
+                        <span id="cvCharRating">0.0</span>
+                        <span id="cvCharRatingCount" class="cv-modal-stat-sub"></span>
+                    </div>
+                    <div class="cv-modal-stat" title="Token count">
+                        <i class="fa-solid fa-message"></i>
+                        <span id="cvCharTokens" class="cv-token-count">0</span> tokens
+                    </div>
+                    <div class="cv-modal-stat" id="cvCharDownloadsStat" style="display: none;" title="Total downloads on CharaVault">
+                        <i class="fa-solid fa-cloud-arrow-down"></i>
+                        <span id="cvCharDownloads">0</span>
+                    </div>
+                    <div class="cv-modal-stat" id="cvCharLorebookStat" style="display: none;" title="Linked lorebook(s)">
+                        <i class="fa-solid fa-book"></i>
+                        <span id="cvCharLorebookText">Lorebook</span>
+                    </div>
+                    <div class="cv-modal-stat" id="cvCharGreetingsStat" style="display: none;" title="Alternate greetings">
+                        <i class="fa-solid fa-comment-dots"></i>
+                        <span id="cvCharGreetingsCount">0</span> greetings
+                    </div>
+                    <div class="cv-modal-stat" id="cvCharNsfwStat" style="display: none;" title="NSFW reasons">
+                        <i class="fa-solid fa-triangle-exclamation"></i>
+                        <span id="cvCharNsfwReasons"></span>
+                    </div>
+                </div>
+                <div class="cv-modal-tier" id="cvCharTierBox" style="display: none;">
+                    <i class="fa-solid fa-microchip"></i>
+                    <div class="cv-modal-tier-text">
+                        <strong id="cvCharTierLabel"></strong>
+                        <span id="cvCharTierDesc"></span>
+                        <span id="cvCharTierPreset" class="cv-modal-tier-preset"></span>
+                    </div>
+                </div>
+                <div class="browse-char-tags" id="cvCharTags"></div>
+
+                <!-- Creator Notes -->
+                <div class="browse-char-section">
+                    <h3 class="browse-section-title" data-section="cvCharCreatorNotes" data-label="Creator's Notes" data-icon="fa-solid fa-feather-pointed" title="Click to expand">
+                        <i class="fa-solid fa-feather-pointed"></i> Creator's Notes
+                    </h3>
+                    <div id="cvCharCreatorNotes" class="scrolling-text">No description available.</div>
+                </div>
+
+                <!-- Character Definition (V2 "description" - the prompt) -->
+                <div class="browse-char-section" id="cvCharDescriptionSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharDescription" data-label="Character Definition" data-icon="fa-solid fa-scroll" title="Click to expand">
+                        <i class="fa-solid fa-scroll"></i> Character Definition
+                    </h3>
+                    <div id="cvCharDescription" class="scrolling-text"></div>
+                </div>
+
+                <!-- Personality (extra prompt notes) -->
+                <div class="browse-char-section" id="cvCharPersonalitySection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharPersonality" data-label="Personality" data-icon="fa-solid fa-brain" title="Click to expand">
+                        <i class="fa-solid fa-brain"></i> Personality
+                    </h3>
+                    <div id="cvCharPersonality" class="scrolling-text"></div>
+                </div>
+
+                <!-- Scenario -->
+                <div class="browse-char-section" id="cvCharScenarioSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharScenario" data-label="Scenario" data-icon="fa-solid fa-theater-masks" title="Click to expand">
+                        <i class="fa-solid fa-theater-masks"></i> Scenario
+                    </h3>
+                    <div id="cvCharScenario" class="scrolling-text"></div>
+                </div>
+
+                <!-- First Message -->
+                <div class="browse-char-section" id="cvCharFirstMsgSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharFirstMsg" data-label="First Message" data-icon="fa-solid fa-message" title="Click to expand">
+                        <i class="fa-solid fa-message"></i> First Message
+                    </h3>
+                    <div id="cvCharFirstMsg" class="scrolling-text first-message-preview"></div>
+                </div>
+
+                <!-- Example Dialogs - collapsed by default since they are usually long -->
+                <div class="browse-char-section browse-section-collapsed" id="cvCharExamplesSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharExamples" data-label="Example Dialogs" data-icon="fa-solid fa-comments" title="Click to expand">
+                        <i class="fa-solid fa-comments"></i> Example Dialogs
+                    </h3>
+                    <div id="cvCharExamples" class="scrolling-text"></div>
+                </div>
+
+                <!-- System Prompt (only shown when present) -->
+                <div class="browse-char-section browse-section-collapsed" id="cvCharSystemPromptSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharSystemPrompt" data-label="System Prompt" data-icon="fa-solid fa-gear" title="Click to expand">
+                        <i class="fa-solid fa-gear"></i> System Prompt
+                    </h3>
+                    <div id="cvCharSystemPrompt" class="scrolling-text"></div>
+                </div>
+
+                <!-- Post-History Instructions (jailbreak slot) -->
+                <div class="browse-char-section browse-section-collapsed" id="cvCharPostHistorySection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharPostHistory" data-label="Post-History Instructions" data-icon="fa-solid fa-flag-checkered" title="Click to expand">
+                        <i class="fa-solid fa-flag-checkered"></i> Post-History Instructions
+                    </h3>
+                    <div id="cvCharPostHistory" class="scrolling-text"></div>
+                </div>
+
+                <!-- Alternate Greetings -->
+                <div class="browse-char-section" id="cvCharAltGreetingsSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="browseAltGreetings" data-label="Alternate Greetings" data-icon="fa-solid fa-comments" title="Click to expand">
+                        <i class="fa-solid fa-comments"></i> Alternate Greetings
+                        <span class="browse-section-count" id="cvCharAltGreetingsCount"></span>
+                    </h3>
+                    <div id="cvCharAltGreetings" class="browse-alt-greetings-list"></div>
+                </div>
+
+                <!-- Linked Lorebooks (live) -->
+                <div class="browse-char-section" id="cvCharLinkedBooksSection" style="display: none;">
+                    <h3 class="browse-section-title" data-section="cvCharLinkedBooks" data-label="Linked Lorebooks" data-icon="fa-solid fa-book" title="Click to expand">
+                        <i class="fa-solid fa-book"></i> Linked Lorebooks
+                        <span class="browse-section-count" id="cvCharLinkedBooksCount"></span>
+                    </h3>
+                    <div id="cvCharLinkedBooks" class="cv-linked-books-list"></div>
+                </div>
+
+                <!-- Similar (visual hash) -->
+                <div class="browse-char-section" id="cvCharSimilarSection">
+                    <h3 class="browse-section-title" data-section="cvCharSimilar" data-label="Visually Similar" data-icon="fa-solid fa-images" title="Click to expand">
+                        <i class="fa-solid fa-images"></i> Visually Similar
+                        <span class="browse-section-count" id="cvCharSimilarCount"></span>
+                    </h3>
+                    <div class="cv-similar-controls">
+                        <button id="cvFindSimilarBtn" class="glass-btn cv-find-similar-btn" title="Find visually similar cards">
+                            <i class="fa-solid fa-magnifying-glass"></i> Find Similar
+                        </button>
+                        <span id="cvSimilarStatus" class="cv-similar-status"></span>
+                    </div>
+                    <div id="cvCharSimilar" class="cv-similar-grid"></div>
+                </div>
+            </div>
+        </div>
+    </div>`;
+    }
+
+    // ── Lifecycle ───────────────────────────────────────────
+
+    init() {
+        super.init();
+        initCvView();
+        this._registerDropdownDismiss([
+            { dropdownId: 'cvFiltersDropdown', buttonId: 'cvFiltersBtn' },
+            { dropdownId: 'cvTagsDropdown', buttonId: 'cvTagsBtn' },
+        ]);
+    }
+
+    applyDefaults(defaults) {
+        if (defaults.sort) {
+            cvSortMode = defaults.sort;
+            const el = document.getElementById('cvSortSelect');
+            if (el) el.value = defaults.sort;
+        }
+    }
+
+    activate(container, options = {}) {
+        if (options.domRecreated) {
+            cvCurrentSearch = '';
+            cvCurrentCreator = '';
+            cvCharacters = [];
+            cvCurrentPage = 0;
+            cvHasMore = true;
+            cvIsLoading = false;
+            cvGridRenderedCount = 0;
+            cvSelectedChar = null;
+        }
+        super.activate(container, options);
+
+        this.buildLocalLibraryLookup();
+        const grid = document.getElementById('cvGrid');
+        if (cvCharacters.length === 0) {
+            loadCvCharacters();
+        } else if (grid && grid.children.length === 0) {
+            cvGridRenderedCount = 0;
+            renderCvGrid();
+        } else {
+            this.reconnectImageObserver();
+        }
+    }
+
+    refreshInLibraryBadges() {
+        super.refreshInLibraryBadges(card => {
+            const fullPath = card.dataset.fullPath;
+            const name = card.querySelector('.browse-card-name')?.textContent || '';
+            return cvIsInLibrary({ fullPath, name });
+        }, ['cvGrid']);
+    }
+
+    deactivate() {
+        super.deactivate();
+        this.disconnectImageObserver();
+    }
+
+    closeDropdowns() {
+        document.getElementById('cvTagsDropdown')?.classList.add('hidden');
+        document.getElementById('cvFiltersDropdown')?.classList.add('hidden');
+    }
+}
+
+// ========================================
+// LOAD & RENDER
+// ========================================
+
+async function loadCvCharacters(reset = false) {
+    if (cvIsLoading) return;
+    if (reset) {
+        cvCharacters = [];
+        cvCurrentPage = 0;
+        cvHasMore = true;
+        cvGridRenderedCount = 0;
+    }
+    if (!cvHasMore) return;
+
+    const token = ++cvLoadToken;
+    cvIsLoading = true;
+
+    const grid = document.getElementById('cvGrid');
+    if (cvCurrentPage === 0 && grid) {
+        renderLoadingState?.(grid, 'Loading CharaVault characters...', 'browse-loading');
+    }
+
+    try {
+        const tagStr = cvTagFilters.size > 0 ? [...cvTagFilters].join(',') : '';
+        // nsfw: 'sfw' -> false, 'nsfw' -> true, 'any' -> null (omit)
+        const nsfwParam = cvNsfwMode === 'sfw' ? false : cvNsfwMode === 'nsfw' ? true : null;
+        // has_book: 'with' -> true, 'without' -> false, 'any' -> null (omit)
+        const hasBookParam = cvLorebookMode === 'with' ? true
+            : cvLorebookMode === 'without' ? false
+                : null;
+        const data = await fetchCvCards({
+            q: cvCurrentSearch,
+            creator: cvCurrentCreator,
+            tags: tagStr,
+            nsfw: nsfwParam,
+            has_book: hasBookParam,
+            sort: cvSortMode,
+            limit: PAGE_SIZE,
+            offset: cvCurrentPage * PAGE_SIZE,
+        });
+
+        if (token !== cvLoadToken) return;
+
+        const results = data.results || [];
+        const total = data.total || 0;
+
+        for (const r of results) {
+            r.fullPath = cvFullPath(r.folder, r.file);
+        }
+
+        if (cvCurrentPage === 0) {
+            cvCharacters = results;
+        } else {
+            cvCharacters = cvCharacters.concat(results);
+        }
+
+        cvHasMore = cvCharacters.length < total && results.length === PAGE_SIZE;
+        renderCvGrid();
+    } catch (e) {
+        if (token !== cvLoadToken) return;
+        debugLog('[CharaVault] loadCvCharacters error:', e.message);
+        if (cvCurrentPage === 0 && grid) {
+            grid.innerHTML = `<div class="browse-error"><i class="fa-solid fa-exclamation-triangle"></i> Failed to load: ${escapeHtml(e.message)}</div>`;
+        }
+        cvHasMore = false;
+    } finally {
+        if (token === cvLoadToken) {
+            cvIsLoading = false;
+            // Loading state is cleared by renderCvGrid() / error fallback,
+            // so no explicit teardown call is needed here.
+        }
+    }
+}
+
+function renderCvGrid(append = false) {
+    const grid = document.getElementById('cvGrid');
+    if (!grid) return;
+
+    const startIdx = append ? cvGridRenderedCount : 0;
+    if (!append) {
+        grid.innerHTML = '';
+        cvGridRenderedCount = 0;
+    }
+
+    const fragment = document.createDocumentFragment();
+    for (let i = startIdx; i < cvCharacters.length; i++) {
+        const char = cvCharacters[i];
+        const card = buildCvCard(char);
+        fragment.appendChild(card);
+    }
+    grid.appendChild(fragment);
+    cvGridRenderedCount = cvCharacters.length;
+
+    view.observeImages(grid);
+    view.updateLoadMoreVisibility('cvLoadMore', cvHasMore, cvCharacters.length > 0);
+}
+
+function buildCvCard(char) {
+    const inLib = cvIsInLibrary(char);
+    const possible = !inLib && cvIsPossibleMatch(char);
+    const thumbUrl = cvThumbUrl(char.folder, char.file);
+    const name = escapeHtml(char.name || 'Unknown');
+    const creator = escapeHtml(char.creator || '');
+    const tokens = char.token_count ? formatNumber(char.token_count) : '';
+    const rating = char.avg_rating ? char.avg_rating.toFixed(1) : '';
+    const hasLore = char.has_lorebook;
+
+    const badges = [];
+    if (inLib) badges.push('<span class="browse-feature-badge in-library" title="In Your Library"><i class="fa-solid fa-check"></i></span>');
+    else if (possible) badges.push('<span class="browse-feature-badge possible-library" title="Possible Match in Library"><i class="fa-solid fa-check"></i></span>');
+    if (hasLore) badges.push('<span class="browse-feature-badge cv-badge-lorebook" title="Has Lorebook"><i class="fa-solid fa-book"></i></span>');
+
+    const card = document.createElement('div');
+    card.className = `browse-card${inLib ? ' in-library' : ''}${possible ? ' possible-library' : ''}`;
+    card.dataset.fullPath = char.fullPath;
+    card.dataset.charIdx = String(cvCharacters.indexOf(char));
+    card.innerHTML = `
+        <div class="browse-card-image">
+            <img data-src="${escapeHtml(thumbUrl)}" src="${IMG_PLACEHOLDER}" alt="${name}" loading="lazy">
+            ${badges.length ? `<div class="browse-feature-badges">${badges.join('')}</div>` : ''}
+        </div>
+        <div class="browse-card-info">
+            <div class="browse-card-name">${name}</div>
+            <div class="browse-card-creator">
+                <a class="browse-card-creator-link" href="#" data-author="${creator}" data-creator-name="${creator}" title="Filter by ${creator}">
+                    ${creator}
+                </a>
+            </div>
+            <div class="browse-card-meta">
+                ${tokens ? `<span title="Tokens"><i class="fa-solid fa-message"></i> ${tokens}</span>` : ''}
+                ${rating ? `<span title="Rating"><i class="fa-solid fa-star"></i> ${rating}</span>` : ''}
+            </div>
+        </div>
+    `;
+    return card;
+}
+
+// ========================================
+// GRID DELEGATE EVENTS
+// ========================================
+
+function setupCvGridDelegates() {
+    const section = document.getElementById('cvBrowseSection');
+    if (!section) return;
+
+    section.addEventListener('click', (e) => {
+        // Creator link
+        const creatorLink = e.target.closest('.browse-card-creator-link');
+        if (creatorLink) {
+            e.preventDefault();
+            e.stopPropagation();
+            const author = creatorLink.dataset.author || '';
+            if (author) filterByCreator(author);
+            return;
+        }
+
+        // Card click -> open preview
+        const card = e.target.closest('.browse-card');
+        if (!card) return;
+        const idx = parseInt(card.dataset.charIdx, 10);
+        const char = cvCharacters[idx];
+        if (char) openCvPreview(char);
+    });
+}
+
+// ========================================
+// CREATOR FILTER
+// ========================================
+
+function filterByCreator(creator) {
+    cvCurrentCreator = creator;
+    cvCurrentSearch = '';
+    const searchInput = document.getElementById('cvSearchInput');
+    if (searchInput) searchInput.value = '';
+    const clearBtn = document.getElementById('cvClearSearchBtn');
+    if (clearBtn) clearBtn.classList.add('hidden');
+
+    const banner = document.getElementById('cvCreatorBanner');
+    const bannerName = document.getElementById('cvCreatorBannerName');
+    if (banner) banner.classList.remove('hidden');
+    if (bannerName) bannerName.textContent = creator;
+
+    loadCvCharacters(true);
+}
+
+function clearCreatorFilter() {
+    cvCurrentCreator = '';
+    const banner = document.getElementById('cvCreatorBanner');
+    if (banner) banner.classList.add('hidden');
+    loadCvCharacters(true);
+}
+
+// ========================================
+// SEARCH
+// ========================================
+
+function performCvSearch() {
+    const input = document.getElementById('cvSearchInput');
+    const q = input ? input.value.trim() : '';
+    cvCurrentSearch = q;
+    cvCurrentCreator = '';
+    const banner = document.getElementById('cvCreatorBanner');
+    if (banner) banner.classList.add('hidden');
+    loadCvCharacters(true);
+}
+
+// ========================================
+// NSFW TOGGLE
+// ========================================
+
+function updateCvNsfwToggle() {
+    const btn = document.getElementById('cvNsfwToggle');
+    if (!btn) return;
+    btn.classList.remove('nsfw-active', 'nsfw-any');
+    const span = btn.querySelector('span');
+    if (cvNsfwMode === 'nsfw') {
+        btn.classList.add('nsfw-active');
+        if (span) span.textContent = 'NSFW Only';
+    } else if (cvNsfwMode === 'any') {
+        btn.classList.add('nsfw-any');
+        if (span) span.textContent = 'NSFW + SFW';
+    } else {
+        if (span) span.textContent = 'SFW Only';
+    }
+}
+
+function cycleCvNsfwMode() {
+    // sfw -> nsfw -> any -> sfw
+    cvNsfwMode = cvNsfwMode === 'sfw' ? 'nsfw' : cvNsfwMode === 'nsfw' ? 'any' : 'sfw';
+}
+
+// ========================================
+// TAGS
+// ========================================
+
+async function loadCvTags() {
+    if (cvTagsLoaded) return;
+    const list = document.getElementById('cvTagsList');
+    if (!list) return;
+
+    try {
+        cvPopularTags = await fetchCvTags();
+        cvTagsLoaded = true;
+        renderCvTagsList('');
+    } catch (e) {
+        if (list) list.innerHTML = '<div class="browse-tags-empty">Could not load tags</div>';
+    }
+}
+
+function renderCvTagsList(filter) {
+    const list = document.getElementById('cvTagsList');
+    if (!list) return;
+
+    const lowerFilter = filter.toLowerCase();
+    const filtered = filter
+        ? cvPopularTags.filter(([t]) => t.toLowerCase().includes(lowerFilter))
+        : cvPopularTags;
+
+    const top = filtered.slice(0, 80);
+    if (top.length === 0) {
+        list.innerHTML = '<div class="browse-tags-empty">No matching tags</div>';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    for (const [tag, count] of top) {
+        const active = cvTagFilters.has(tag);
+        const el = document.createElement('button');
+        el.className = `browse-tag-pill${active ? ' active' : ''}`;
+        el.dataset.tag = tag;
+        el.title = `${tag} (${formatNumber(count)})`;
+        el.textContent = tag;
+        fragment.appendChild(el);
+    }
+    list.innerHTML = '';
+    list.appendChild(fragment);
+}
+
+function toggleCvTag(tag) {
+    if (cvTagFilters.has(tag)) {
+        cvTagFilters.delete(tag);
+    } else {
+        cvTagFilters.add(tag);
+    }
+    updateCvTagsBtn();
+    renderCvTagsList(document.getElementById('cvTagsSearchInput')?.value || '');
+    loadCvCharacters(true);
+}
+
+function updateCvTagsBtn() {
+    const label = document.getElementById('cvTagsBtnLabel');
+    const btn = document.getElementById('cvTagsBtn');
+    if (!label || !btn) return;
+    if (cvTagFilters.size > 0) {
+        label.textContent = `Tags (${cvTagFilters.size})`;
+        btn.classList.add('active');
+    } else {
+        label.textContent = 'Tags';
+        btn.classList.remove('active');
+    }
+}
+
+function updateCvFiltersBtn() {
+    const btn = document.getElementById('cvFiltersBtn');
+    if (!btn) return;
+    btn.classList.toggle('active', cvLorebookMode !== 'any');
+}
+
+// ========================================
+// PREVIEW MODAL
+// ========================================
+
+async function openCvPreview(char) {
+    cvSelectedChar = char;
+    const modal = document.getElementById('cvCharModal');
+    if (!modal) return;
+
+    // Reset modal state
+    const avatar = document.getElementById('cvCharAvatar');
+    const nameEl = document.getElementById('cvCharName');
+    const creatorEl = document.getElementById('cvCharCreator');
+    const ratingEl = document.getElementById('cvCharRating');
+    const ratingCountEl = document.getElementById('cvCharRatingCount');
+    const tokensEl = document.getElementById('cvCharTokens');
+    const tagsEl = document.getElementById('cvCharTags');
+    const downloadsStat = document.getElementById('cvCharDownloadsStat');
+    const downloadsEl = document.getElementById('cvCharDownloads');
+    const lorebookStat = document.getElementById('cvCharLorebookStat');
+    const lorebookTextEl = document.getElementById('cvCharLorebookText');
+    const greetingsStat = document.getElementById('cvCharGreetingsStat');
+    const greetingsCount = document.getElementById('cvCharGreetingsCount');
+    const nsfwStat = document.getElementById('cvCharNsfwStat');
+    const nsfwReasonsEl = document.getElementById('cvCharNsfwReasons');
+    const tierBox = document.getElementById('cvCharTierBox');
+    const tierLabel = document.getElementById('cvCharTierLabel');
+    const tierDesc = document.getElementById('cvCharTierDesc');
+    const tierPreset = document.getElementById('cvCharTierPreset');
+    const openBtn = document.getElementById('cvOpenInBrowserBtn');
+    const downloadBtn = document.getElementById('cvDownloadBtn');
+    const notesEl = document.getElementById('cvCharCreatorNotes');
+    const descSection = document.getElementById('cvCharDescriptionSection');
+    const descEl = document.getElementById('cvCharDescription');
+    const personalitySection = document.getElementById('cvCharPersonalitySection');
+    const personalityEl = document.getElementById('cvCharPersonality');
+    const scenarioSection = document.getElementById('cvCharScenarioSection');
+    const scenarioEl = document.getElementById('cvCharScenario');
+    const firstMsgSection = document.getElementById('cvCharFirstMsgSection');
+    const firstMsgEl = document.getElementById('cvCharFirstMsg');
+    const examplesSection = document.getElementById('cvCharExamplesSection');
+    const examplesEl = document.getElementById('cvCharExamples');
+    const systemPromptSection = document.getElementById('cvCharSystemPromptSection');
+    const systemPromptEl = document.getElementById('cvCharSystemPrompt');
+    const postHistorySection = document.getElementById('cvCharPostHistorySection');
+    const postHistoryEl = document.getElementById('cvCharPostHistory');
+    const altGreetingsSection = document.getElementById('cvCharAltGreetingsSection');
+    const altGreetingsEl = document.getElementById('cvCharAltGreetings');
+    const altGreetingsCountEl = document.getElementById('cvCharAltGreetingsCount');
+
+    const thumbUrl = cvThumbUrl(char.folder, char.file);
+    const fullPath = char.fullPath;
+
+    if (avatar) { avatar.src = thumbUrl; avatar.alt = char.name || ''; }
+    if (nameEl) nameEl.textContent = char.name || 'Unknown';
+    if (creatorEl) {
+        creatorEl.textContent = char.creator || 'Unknown';
+        creatorEl.href = '#';
+        creatorEl.dataset.creator = char.creator || '';
+    }
+    if (ratingEl) ratingEl.textContent = char.avg_rating ? char.avg_rating.toFixed(1) : '0.0';
+    if (ratingCountEl) ratingCountEl.textContent = char.rating_count ? `(${formatNumber(char.rating_count)})` : '';
+    if (tokensEl) tokensEl.textContent = char.token_count ? formatNumber(char.token_count) : '0';
+    if (downloadsStat) downloadsStat.style.display = char.download_count ? '' : 'none';
+    if (downloadsEl) downloadsEl.textContent = char.download_count ? formatNumber(char.download_count) : '0';
+    if (lorebookStat) {
+        lorebookStat.style.display = char.has_lorebook ? '' : 'none';
+        if (lorebookTextEl) lorebookTextEl.textContent = 'Lorebook';
+    }
+    if (nsfwStat) {
+        const reasons = (char.nsfw_reasons || []).filter(Boolean);
+        if (char.nsfw && reasons.length > 0) {
+            nsfwStat.style.display = '';
+            if (nsfwReasonsEl) nsfwReasonsEl.textContent = reasons.join(', ');
+        } else {
+            nsfwStat.style.display = 'none';
+        }
+    }
+    if (tierBox) tierBox.style.display = 'none';
+    if (greetingsStat) greetingsStat.style.display = 'none';
+
+    if (tagsEl) {
+        const excludeTags = getProviderExcludeTags?.() || [];
+        const filtered = (char.tags || []).filter(t => !excludeTags.includes(t));
+        tagsEl.innerHTML = filtered.map(t =>
+            `<span class="browse-tag">${escapeHtml(t)}</span>`
+        ).join('');
+    }
+
+    if (openBtn) openBtn.href = `https://charavault.net/cards/preview/${encodeURIComponent(char.folder)}/${encodeURIComponent(char.file)}`;
+    if (downloadBtn) {
+        downloadBtn.disabled = false;
+        downloadBtn.innerHTML = '<i class="fa-solid fa-download"></i> Import';
+    }
+
+    // Show preview text from browse list data while we fetch full data
+    if (notesEl) {
+        const preview = char.description_preview || '';
+        notesEl.textContent = preview || 'Loading...';
+    }
+    // Reset all dynamic sections to hidden; populated below from full metadata.
+    for (const s of [descSection, personalitySection, scenarioSection,
+                     firstMsgSection, examplesSection, systemPromptSection,
+                     postHistorySection, altGreetingsSection]) {
+        if (s) s.style.display = 'none';
+    }
+    for (const el of [descEl, personalityEl, scenarioEl, firstMsgEl,
+                      examplesEl, systemPromptEl, postHistoryEl]) {
+        if (el) {
+            el.innerHTML = '';
+            delete el.dataset.fullContent;
+        }
+    }
+
+    modal.classList.remove('hidden');
+
+    // Fetch full metadata + live rating + linked lorebooks in parallel.
+    // Each is best-effort; failure of one doesn't block the rest.
+    let detail = null;
+    let liveRating = null;
+    let linkedLorebooks = null;
+    try {
+        [detail, liveRating, linkedLorebooks] = await Promise.all([
+            fetchCvCardDetail(fullPath),
+            fetchCvRating(fullPath),
+            fetchCvLinkedLorebooks(fullPath),
+        ]);
+    } catch (e) {
+        debugLog('[CharaVault] openCvPreview parallel fetch error:', e.message);
+    }
+    // Bail if user navigated away while we were fetching.
+    if (cvSelectedChar?.fullPath !== fullPath) return;
+
+    // Live rating refresh - the value in the search-list row may be stale.
+    if (liveRating) {
+        if (ratingEl) ratingEl.textContent = (liveRating.avg_rating || 0).toFixed(1);
+        if (ratingCountEl) ratingCountEl.textContent = liveRating.rating_count
+            ? `(${formatNumber(liveRating.rating_count)})` : '';
+    }
+
+    // Linked lorebooks - shows even if has_lorebook flag is missing.
+    const linkedCount = linkedLorebooks?.lorebooks?.length || 0;
+    if (linkedCount > 0 && lorebookStat) {
+        lorebookStat.style.display = '';
+        if (lorebookTextEl) lorebookTextEl.textContent = `${linkedCount} lorebook${linkedCount === 1 ? '' : 's'}`;
+    }
+
+    // Bail out of detail-dependent UI if detail fetch failed.
+    if (!detail) return;
+
+    try {
+        const meta = detail.fullMetadata?.data || {};
+        const entry = detail.entry || {};
+        const recs = detail.recommendations || null;
+
+        // Tier hint (model class recommendation).
+        if (tierBox && recs && (recs.tier_label || recs.tier_description)) {
+            tierBox.style.display = '';
+            if (tierLabel) tierLabel.textContent = recs.tier_label || '';
+            if (tierDesc) tierDesc.textContent = recs.tier_description || '';
+            if (tierPreset) tierPreset.textContent = recs.suggested_preset
+                ? `Preset: ${recs.suggested_preset}`
+                : '';
+        }
+
+        // Live downloads from detail entry (search-list row already had it,
+        // but detail wins if both are present).
+        if (downloadsStat && entry.download_count) {
+            downloadsStat.style.display = '';
+            if (downloadsEl) downloadsEl.textContent = formatNumber(entry.download_count);
+        }
+
+        if (notesEl) {
+            cleanupCreatorNotesContainer?.(notesEl);
+            const notes = meta.creator_notes || char.description_preview || 'No description available.';
+            if (renderCreatorNotesSecure) {
+                renderCreatorNotesSecure(notes, char.name || '', notesEl);
+            } else {
+                notesEl.textContent = notes;
+            }
+        }
+
+        const cName = char.name || meta.name || '';
+        // Helper: render rich-text with full-content stash for the "expand"
+        // modal that core opens on section-title click.
+        const renderRich = (section, el, value) => {
+            if (!section || !el || !value) return;
+            section.style.display = '';
+            el.innerHTML = safePurify(formatRichText(value, cName, true), BROWSE_PURIFY_CONFIG);
+            el.dataset.fullContent = value;
+        };
+
+        renderRich(descSection, descEl, meta.description);
+        renderRich(personalitySection, personalityEl, meta.personality);
+        renderRich(scenarioSection, scenarioEl, meta.scenario);
+        renderRich(firstMsgSection, firstMsgEl, meta.first_mes);
+        renderRich(examplesSection, examplesEl, meta.mes_example);
+        renderRich(systemPromptSection, systemPromptEl, meta.system_prompt);
+        renderRich(postHistorySection, postHistoryEl, meta.post_history_instructions);
+
+        const alts = meta.alternate_greetings || [];
+        if (altGreetingsEl && alts.length > 0) {
+            altGreetingsSection.style.display = '';
+            if (altGreetingsCountEl) altGreetingsCountEl.textContent = `(${alts.length})`;
+            if (greetingsStat) {
+                greetingsStat.style.display = '';
+                if (greetingsCount) greetingsCount.textContent = alts.length + 1;
+            }
+            // Lazy-render alt greeting bodies on first <details> open. Saves
+            // a lot of formatRichText work if the user never expands them.
+            const buildPreview = (text) => {
+                const cleaned = (text || '').replace(/\s+/g, ' ').trim();
+                if (!cleaned) return 'No content';
+                return cleaned.length > 90 ? `${cleaned.slice(0, 87)}\u2026` : cleaned;
+            };
+            altGreetingsEl.innerHTML = alts.map((g, i) =>
+                `<details class="browse-alt-greeting" data-greeting-idx="${i}">
+                    <summary>
+                        <span class="browse-alt-greeting-index">#${i + 1}</span>
+                        <span class="browse-alt-greeting-preview">${escapeHtml(buildPreview(g))}</span>
+                        <span class="browse-alt-greeting-chevron"><i class="fa-solid fa-chevron-down"></i></span>
+                    </summary>
+                    <div class="browse-alt-greeting-body"></div>
+                </details>`
+            ).join('');
+            altGreetingsEl.querySelectorAll('details.browse-alt-greeting').forEach(details => {
+                details.addEventListener('toggle', function onToggle() {
+                    if (!details.open) return;
+                    const body = details.querySelector('.browse-alt-greeting-body');
+                    if (body && !body.dataset.rendered) {
+                        const idx = parseInt(details.dataset.greetingIdx, 10);
+                        if (alts[idx] != null) {
+                            body.innerHTML = safePurify(formatRichText(alts[idx], cName, true), BROWSE_PURIFY_CONFIG);
+                        }
+                        body.dataset.rendered = '1';
+                    }
+                }, { once: true });
+            });
+            // Expose for the core's fullscreen alt-greetings modal.
+            window.currentBrowseAltGreetings = alts;
+        } else {
+            window.currentBrowseAltGreetings = [];
+        }
+
+        // Linked lorebooks list (already fetched in parallel above).
+        const linkedBooksSection = document.getElementById('cvCharLinkedBooksSection');
+        const linkedBooksEl = document.getElementById('cvCharLinkedBooks');
+        const linkedBooksCountEl = document.getElementById('cvCharLinkedBooksCount');
+        if (linkedBooksSection && linkedBooksEl) {
+            const books = linkedLorebooks?.lorebooks || [];
+            if (books.length > 0) {
+                linkedBooksSection.style.display = '';
+                if (linkedBooksCountEl) linkedBooksCountEl.textContent = `(${books.length})`;
+                linkedBooksEl.innerHTML = books.map(b => {
+                    const id = escapeHtml(b.id || '');
+                    const title = escapeHtml(b.title || b.name || `Lorebook ${id}`);
+                    const entries = b.entry_count != null ? ` &middot; ${formatNumber(b.entry_count)} entries` : '';
+                    return `<div class="cv-linked-book">
+                        <i class="fa-solid fa-book"></i>
+                        <span class="cv-linked-book-title">${title}</span>
+                        <span class="cv-linked-book-meta">${entries}</span>
+                    </div>`;
+                }).join('');
+            } else {
+                linkedBooksSection.style.display = 'none';
+            }
+        }
+    } catch (e) {
+        debugLog('[CharaVault] openCvPreview detail render error:', e.message);
+    }
+
+    // Reset similar section to its idle state. The user opts into the
+    // /cards/similar fetch via the "Find Similar" button - it can be slow
+    // and many cards have no image-hash match.
+    const simEl = document.getElementById('cvCharSimilar');
+    const simCountEl = document.getElementById('cvCharSimilarCount');
+    const simStatus = document.getElementById('cvSimilarStatus');
+    const simBtn = document.getElementById('cvFindSimilarBtn');
+    if (simEl) simEl.innerHTML = '';
+    if (simCountEl) simCountEl.textContent = '';
+    if (simStatus) simStatus.textContent = '';
+    if (simBtn) {
+        simBtn.disabled = false;
+        simBtn.innerHTML = '<i class="fa-solid fa-magnifying-glass"></i> Find Similar';
+    }
+}
+
+async function loadCvSimilar(diskPath) {
+    const simEl = document.getElementById('cvCharSimilar');
+    const simCountEl = document.getElementById('cvCharSimilarCount');
+    const simStatus = document.getElementById('cvSimilarStatus');
+    const simBtn = document.getElementById('cvFindSimilarBtn');
+    if (simBtn) {
+        simBtn.disabled = true;
+        simBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Searching...';
+    }
+    if (simStatus) simStatus.textContent = '';
+    try {
+        // Capture the active fullPath at call time so concurrent opens of
+        // other cards do not mistakenly render this result set.
+        const callerFullPath = cvSelectedChar?.fullPath;
+        const res = await fetchCvSimilar(diskPath);
+        if (cvSelectedChar?.fullPath !== callerFullPath) return;
+        if (!simEl) return;
+        const results = res?.results || [];
+        if (!res?.ok) {
+            simEl.innerHTML = '';
+            if (simCountEl) simCountEl.textContent = '';
+            if (simStatus) {
+                if (res?.reason === 'no_hash') {
+                    simStatus.textContent = 'This card has no image-hash entry on CharaVault, so visual similarity is unavailable.';
+                } else if (res?.reason === 'http') {
+                    simStatus.textContent = `Server returned HTTP ${res.status}.`;
+                } else {
+                    simStatus.textContent = `Error: ${res?.error || 'unknown'}`;
+                }
+            }
+            return;
+        }
+        if (results.length === 0) {
+            simEl.innerHTML = '';
+            if (simCountEl) simCountEl.textContent = '';
+            if (simStatus) simStatus.textContent = 'No visually similar cards found.';
+            return;
+        }
+        if (simCountEl) simCountEl.textContent = `(${results.length})`;
+        simEl.innerHTML = results.map(s => {
+            const folder = s.folder || '';
+            const file = s.file || '';
+            const fp = cvFullPath(folder, file);
+            const thumb = cvThumbUrl(folder, file);
+            const name = escapeHtml(s.name || file || 'Unknown');
+            const creator = s.creator && s.creator !== 'Unknown'
+                ? `<div class="cv-similar-card-creator">${escapeHtml(s.creator)}</div>`
+                : '';
+            const score = (typeof s.score === 'number')
+                ? `<div class="cv-similar-card-score" title="Match score">${s.score.toFixed(0)}%</div>`
+                : '';
+            const reasons = Array.isArray(s.reasons) && s.reasons.length
+                ? escapeHtml(s.reasons.join(', '))
+                : '';
+            const tooltip = reasons ? `${name} \u2014 ${reasons}` : name;
+            return `<div class="cv-similar-card" data-full-path="${escapeHtml(fp)}" title="${tooltip}">
+                <div class="cv-similar-card-thumb">
+                    <img src="${escapeHtml(thumb)}" alt="${name}" loading="lazy">
+                    ${score}
+                </div>
+                <div class="cv-similar-card-name">${name}</div>
+                ${creator}
+            </div>`;
+        }).join('');
+    } catch (e) {
+        debugLog('[CharaVault] loadCvSimilar error:', e);
+        if (simStatus) simStatus.textContent = `Error: ${e.message || e}`;
+    } finally {
+        if (simBtn && document.contains(simBtn)) {
+            simBtn.disabled = false;
+            simBtn.innerHTML = '<i class="fa-solid fa-rotate"></i> Search again';
+        }
+    }
+}
+
+// ========================================
+// INIT EVENT HANDLERS
+// ========================================
+
+function initCvView() {
+    const sortEl = document.getElementById('cvSortSelect');
+    if (sortEl) {
+        sortEl.value = cvSortMode;
+        CoreAPI.initCustomSelect?.(sortEl);
+    }
+    updateCvNsfwToggle();
+    setupCvGridDelegates();
+
+    // Sort change
+    on('cvSortSelect', 'change', (e) => {
+        cvSortMode = e.target.value;
+        loadCvCharacters(true);
+    });
+
+    // Search input
+    on('cvSearchInput', 'keypress', (e) => { if (e.key === 'Enter') performCvSearch(); });
+    on('cvSearchInput', 'input', (e) => {
+        const clearBtn = document.getElementById('cvClearSearchBtn');
+        if (clearBtn) clearBtn.classList.toggle('hidden', !e.target.value.trim());
+    });
+    on('cvSearchBtn', 'click', () => performCvSearch());
+    on('cvClearSearchBtn', 'click', () => {
+        const input = document.getElementById('cvSearchInput');
+        if (input) { input.value = ''; input.focus(); }
+        document.getElementById('cvClearSearchBtn')?.classList.add('hidden');
+        performCvSearch();
+    });
+
+    // Creator filter
+    on('cvCreatorSearchInput', 'keypress', (e) => {
+        if (e.key === 'Enter') {
+            const val = document.getElementById('cvCreatorSearchInput')?.value.trim();
+            if (val) filterByCreator(val);
+        }
+    });
+    on('cvCreatorSearchBtn', 'click', () => {
+        const val = document.getElementById('cvCreatorSearchInput')?.value.trim();
+        if (val) filterByCreator(val);
+    });
+    on('cvClearCreatorBtn', 'click', () => {
+        const input = document.getElementById('cvCreatorSearchInput');
+        if (input) input.value = '';
+        clearCreatorFilter();
+    });
+
+    // NSFW toggle (3-state cycle)
+    on('cvNsfwToggle', 'click', () => {
+        cycleCvNsfwMode();
+        updateCvNsfwToggle();
+        loadCvCharacters(true);
+    });
+
+    // Refresh
+    on('refreshCvBtn', 'click', () => loadCvCharacters(true));
+
+    // Load more button
+    on('cvLoadMoreBtn', 'click', async () => {
+        if (cvIsLoading) return;
+        cvCurrentPage++;
+        await loadCvCharacters();
+    });
+
+    // Filters dropdown
+    on('cvFiltersBtn', 'click', (e) => {
+        e.stopPropagation();
+        CoreAPI.closeAllTopbarDropdowns?.();
+        document.getElementById('cvTagsDropdown')?.classList.add('hidden');
+        document.getElementById('cvFiltersDropdown')?.classList.toggle('hidden');
+    });
+    // Lorebook 3-state radio
+    document.querySelectorAll('input[name="cvLorebookMode"]').forEach(input => {
+        input.addEventListener('change', (e) => {
+            if (!e.target.checked) return;
+            cvLorebookMode = e.target.value;
+            updateCvFiltersBtn();
+            loadCvCharacters(true);
+        });
+    });
+
+    // Tags dropdown
+    on('cvTagsBtn', 'click', (e) => {
+        e.stopPropagation();
+        CoreAPI.closeAllTopbarDropdowns?.();
+        document.getElementById('cvFiltersDropdown')?.classList.add('hidden');
+        const dropdown = document.getElementById('cvTagsDropdown');
+        const wasHidden = dropdown?.classList.contains('hidden');
+        dropdown?.classList.toggle('hidden');
+        if (wasHidden) loadCvTags();
+    });
+
+    on('cvTagsSearchInput', 'input', (e) => {
+        renderCvTagsList(e.target.value);
+    });
+
+    on('cvTagsClearBtn', 'click', () => {
+        cvTagFilters.clear();
+        updateCvTagsBtn();
+        const searchInput = document.getElementById('cvTagsSearchInput');
+        if (searchInput) searchInput.value = '';
+        renderCvTagsList('');
+        loadCvCharacters(true);
+    });
+
+    const tagsList = document.getElementById('cvTagsList');
+    if (tagsList) {
+        tagsList.addEventListener('click', (e) => {
+            const pill = e.target.closest('.browse-tag-pill');
+            if (pill) toggleCvTag(pill.dataset.tag);
+        });
+    }
+
+    // Modal events
+    on('cvCharClose', 'click', () => {
+        const notesEl = document.getElementById('cvCharCreatorNotes');
+        if (notesEl) cleanupCreatorNotesContainer?.(notesEl);
+        hideModal('cvCharModal');
+        cvSelectedChar = null;
+    });
+
+    on('cvCharCreator', 'click', (e) => {
+        e.preventDefault();
+        const creator = e.target.dataset.creator || '';
+        if (creator) {
+            hideModal('cvCharModal');
+            cvSelectedChar = null;
+            filterByCreator(creator);
+        }
+    });
+
+    // Modal-level event delegation. Handlers bind to the modal root once, so
+    // they survive innerHTML rewrites of inner sections and are not racey with
+    // initCvView() ordering. Fire & forget: handlers never throw out.
+    const modal = document.getElementById('cvCharModal');
+    if (modal) {
+        modal.addEventListener('click', async (e) => {
+            // Similar-card click - open that character's preview by fetching
+            // the row from the card list. Falls back to a synthetic char.
+            const simCard = e.target.closest('.cv-similar-card[data-full-path]');
+            if (simCard) {
+                const fp = simCard.dataset.fullPath;
+                if (!fp) return;
+                // Look up in current grid first.
+                const known = cvCharacters.find(c => c.fullPath === fp);
+                if (known) {
+                    openCvPreview(known);
+                } else {
+                    // Synthetic char - openCvPreview tolerates missing fields
+                    // and will fetch detail asynchronously.
+                    const slash = fp.indexOf('/');
+                    const folder = slash >= 0 ? fp.slice(0, slash) : '';
+                    const file = slash >= 0 ? fp.slice(slash + 1) : fp;
+                    openCvPreview({ fullPath: fp, folder, file, name: file.replace(/\.png$/i, '') });
+                }
+                return;
+            }
+
+            // Section title clicks are handled globally by the core's
+            // initBrowseExpandButtons() (opens fullscreen expand modal /
+            // toggles inline collapse based on user setting). Do not
+            // intercept them here - that previously broke the expand modal.
+
+
+            // Find Similar button - opt-in /cards/similar fetch.
+            const findSimBtn = e.target.closest('#cvFindSimilarBtn');
+            if (findSimBtn) {
+                e.preventDefault();
+                const char = cvSelectedChar;
+                if (!char?.fullPath) {
+                    return;
+                }
+                // Backend takes the absolute server-side disk path, not
+                // folder/file. entry.path is populated by both search-list
+                // rows and detail responses; fall back to detail fetch only
+                // if it is missing for some reason.
+                let diskPath = char.path;
+                if (!diskPath) {
+                    try {
+                        const detail = await fetchCvCardDetail(char.fullPath);
+                        diskPath = detail?.entry?.path || null;
+                    } catch { /* ignore */ }
+                }
+                if (!diskPath) {
+                    debugLog('[CharaVault] Find Similar: no entry.path for', char.fullPath);
+                    if (typeof showToast === 'function') showToast('No image-hash path on record for this card', 'warning');
+                    return;
+                }
+                await loadCvSimilar(diskPath);
+                return;
+            }
+
+            // Import button (also fires when icon inside is clicked)
+            const importBtn = e.target.closest('#cvDownloadBtn');
+            if (importBtn) {
+                e.preventDefault();
+                const char = cvSelectedChar;
+                if (!char) {
+                    return;
+                }
+                if (typeof window.cvImportCharacter !== 'function') {
+                    debugLog('[CharaVault] window.cvImportCharacter is not registered. Provider init() may have failed.');
+                    showToast?.('CharaVault provider not initialized', 'error');
+                    return;
+                }
+                importBtn.disabled = true;
+                const origHtml = importBtn.innerHTML;
+                importBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Importing...';
+                try {
+                    const result = await window.cvImportCharacter(char.fullPath, char);
+                    if (result?.success) {
+                        markCvCardImported(char.fullPath);
+                        showToast?.(`Imported "${result.characterName}"`, 'success');
+                    } else {
+                        showToast?.(`Import failed: ${result?.error || 'unknown'}`, 'error');
+                    }
+                } catch (err) {
+                    debugLog('[CharaVault] Import threw:', err);
+                    showToast?.(`Import failed: ${err.message || err}`, 'error');
+                } finally {
+                    if (document.contains(importBtn)) {
+                        importBtn.disabled = false;
+                        importBtn.innerHTML = origHtml;
+                    }
+                }
+                return;
+            }
+        });
+    }
+}
+
+// ========================================
+// EXPORTS
+// ========================================
+
+// Expose for the download button handler wired in initCvView
+export { loadCvCharacters, markCvCardImported };
+
+const charavaultBrowseView = new CharaVaultBrowseView(null);
+export default charavaultBrowseView;

--- a/modules/providers/charavault/charavault-browse.js
+++ b/modules/providers/charavault/charavault-browse.js
@@ -606,34 +606,57 @@ function buildCvCard(char) {
     const name = escapeHtml(char.name || 'Unknown');
     const creator = escapeHtml(char.creator || '');
     const tokens = char.token_count ? formatNumber(char.token_count) : '';
-    const rating = char.avg_rating ? char.avg_rating.toFixed(1) : '';
-    const hasLore = char.has_lorebook;
+    const rating = (typeof char.avg_rating === 'number' && char.avg_rating > 0) ? char.avg_rating.toFixed(1) : '';
+    const ratingCount = char.rating_count || 0;
+    const downloads = char.download_count ? formatNumber(char.download_count) : '';
+    const hasLore = !!char.has_lorebook;
+    const isNsfw = !!char.nsfw;
+    const tagline = char.description_preview ? char.description_preview.slice(0, 200) : '';
+    const taglineTooltip = tagline ? escapeHtml(tagline) : '';
+
+    // Up to 3 tags, mirrors the chub layout.
+    const tags = Array.isArray(char.tags) ? char.tags.slice(0, 3) : [];
+
+    // Indexed_at is the closest analogue to chub's createdAt - it's when CV's
+    // crawler picked the card up, which is the only date the API exposes.
+    const indexedDate = char.indexed_at ? new Date(char.indexed_at).toLocaleDateString() : '';
+    const dateInfo = indexedDate
+        ? `<span class="browse-card-date" title="Indexed"><i class="fa-solid fa-clock"></i> ${indexedDate}</span>`
+        : '';
 
     const badges = [];
-    if (inLib) badges.push('<span class="browse-feature-badge in-library" title="In Your Library"><i class="fa-solid fa-check"></i></span>');
-    else if (possible) badges.push('<span class="browse-feature-badge possible-library" title="Possible Match in Library"><i class="fa-solid fa-check"></i></span>');
-    if (hasLore) badges.push('<span class="browse-feature-badge cv-badge-lorebook" title="Has Lorebook"><i class="fa-solid fa-book"></i></span>');
+    if (inLib) {
+        badges.push('<span class="browse-feature-badge in-library" title="In Your Library"><i class="fa-solid fa-check"></i></span>');
+    } else if (possible) {
+        badges.push('<span class="browse-feature-badge possible-library" title="Possible Match in Library"><i class="fa-solid fa-check"></i></span>');
+    }
+    if (hasLore) {
+        badges.push('<span class="browse-feature-badge" title="Has Lorebook"><i class="fa-solid fa-book"></i></span>');
+    }
 
     const card = document.createElement('div');
     card.className = `browse-card${inLib ? ' in-library' : ''}${possible ? ' possible-library' : ''}`;
     card.dataset.fullPath = char.fullPath;
     card.dataset.charIdx = String(cvCharacters.indexOf(char));
+    if (taglineTooltip) card.title = taglineTooltip;
     card.innerHTML = `
         <div class="browse-card-image">
-            <img data-src="${escapeHtml(thumbUrl)}" src="${IMG_PLACEHOLDER}" alt="${name}" loading="lazy">
+            <img data-src="${escapeHtml(thumbUrl)}" src="${IMG_PLACEHOLDER}" alt="${name}" loading="lazy" decoding="async" fetchpriority="low">
+            ${isNsfw ? '<span class="browse-nsfw-badge">NSFW</span>' : ''}
             ${badges.length ? `<div class="browse-feature-badges">${badges.join('')}</div>` : ''}
         </div>
-        <div class="browse-card-info">
+        <div class="browse-card-body">
             <div class="browse-card-name">${name}</div>
-            <div class="browse-card-creator">
-                <a class="browse-card-creator-link" href="#" data-author="${creator}" data-creator-name="${creator}" title="Filter by ${creator}">
-                    ${creator}
-                </a>
+            ${creator ? `<span class="browse-card-creator-link" data-author="${creator}" data-creator-name="${creator}" title="Click to see all characters by ${creator}">${creator}</span>` : ''}
+            <div class="browse-card-tags">
+                ${tags.map(t => `<span class="browse-card-tag" title="${escapeHtml(t)}">${escapeHtml(t)}</span>`).join('')}
             </div>
-            <div class="browse-card-meta">
-                ${tokens ? `<span title="Tokens"><i class="fa-solid fa-message"></i> ${tokens}</span>` : ''}
-                ${rating ? `<span title="Rating"><i class="fa-solid fa-star"></i> ${rating}</span>` : ''}
-            </div>
+        </div>
+        <div class="browse-card-footer">
+            ${rating ? `<span class="browse-card-stat" title="${ratingCount} rating${ratingCount !== 1 ? 's' : ''}"><i class="fa-solid fa-star"></i> ${rating}</span>` : ''}
+            ${tokens ? `<span class="browse-card-stat" title="Tokens"><i class="fa-solid fa-message"></i> ${tokens}</span>` : ''}
+            ${downloads ? `<span class="browse-card-stat" title="Downloads"><i class="fa-solid fa-download"></i> ${downloads}</span>` : ''}
+            ${dateInfo}
         </div>
     `;
     return card;

--- a/modules/providers/charavault/charavault-provider.js
+++ b/modules/providers/charavault/charavault-provider.js
@@ -6,6 +6,7 @@ import { assignGalleryId, importFromPng, slugify } from '../provider-utils.js';
 import charavaultBrowseView, { markCvCardImported } from './charavault-browse.js';
 import {
     initCvApi,
+    getCvCdnBase,
     getCvHeaders,
     cvThumbUrl,
     cvDownloadUrl,
@@ -28,6 +29,7 @@ class CharaVaultProvider extends ProviderBase {
     get id() { return 'charavault'; }
     get name() { return 'CharaVault'; }
     get icon() { return 'fa-solid fa-vault'; }
+    get iconUrl() { return `${getCvCdnBase()}/favicon.ico`; }
     get browseView() { return charavaultBrowseView; }
 
     // ── Lifecycle ───────────────────────────────────────────

--- a/modules/providers/charavault/charavault-provider.js
+++ b/modules/providers/charavault/charavault-provider.js
@@ -1,0 +1,363 @@
+// CharaVault Provider - character source backed by charavault.net
+
+import { ProviderBase } from '../provider-interface.js';
+import CoreAPI from '../../core-api.js';
+import { assignGalleryId, importFromPng, slugify } from '../provider-utils.js';
+import charavaultBrowseView, { markCvCardImported } from './charavault-browse.js';
+import {
+    initCvApi,
+    getCvHeaders,
+    cvThumbUrl,
+    cvDownloadUrl,
+    cvFullPath,
+    splitCvPath,
+    fetchCvCards,
+    fetchCvCardDetail,
+    buildCvCharacterCard,
+    cvMetadataCache,
+} from './charavault-api.js';
+
+let api = null;
+
+// Cached raw API node from fetchLinkStats - reused by getCachedLinkNode
+let _cachedLinkNode = null;
+
+class CharaVaultProvider extends ProviderBase {
+    // ── Identity ────────────────────────────────────────────
+
+    get id() { return 'charavault'; }
+    get name() { return 'CharaVault'; }
+    get icon() { return 'fa-solid fa-vault'; }
+    get browseView() { return charavaultBrowseView; }
+
+    // ── Lifecycle ───────────────────────────────────────────
+
+    async init(coreAPI) {
+        super.init(coreAPI);
+        api = coreAPI;
+        initCvApi({ getSetting: coreAPI.getSetting, debugLog: coreAPI.debugLog });
+        // Expose import function for the browse modal download button
+        window.cvImportCharacter = (fullPath, hitData, options) =>
+            this.importCharacter(fullPath, hitData, options);
+    }
+
+    async activate(container, options = {}) {
+        charavaultBrowseView.activate(container, options);
+    }
+
+    deactivate() {
+        charavaultBrowseView.deactivate();
+    }
+
+    // ── View ────────────────────────────────────────────────
+
+    get hasView() { return true; }
+
+    renderFilterBar() { return charavaultBrowseView.renderFilterBar(); }
+    renderView() { return charavaultBrowseView.renderView(); }
+    renderModals() { return charavaultBrowseView.renderModals(); }
+
+    // ── Character Linking ───────────────────────────────────
+
+    getLinkInfo(char) {
+        if (!char) return null;
+        const ext = char.data?.extensions?.charavault;
+        if (!ext?.full_path) return null;
+        return {
+            providerId: 'charavault',
+            id: ext.full_path,
+            fullPath: ext.full_path,
+            linkedAt: ext.linkedAt || null,
+        };
+    }
+
+    setLinkInfo(char, linkInfo) {
+        if (!char) return;
+        if (!char.data) char.data = {};
+        if (!char.data.extensions) char.data.extensions = {};
+        if (linkInfo) {
+            const existing = char.data.extensions.charavault || {};
+            char.data.extensions.charavault = {
+                ...existing,
+                full_path: linkInfo.fullPath,
+                linkedAt: linkInfo.linkedAt || new Date().toISOString(),
+            };
+        } else {
+            delete char.data.extensions.charavault;
+        }
+    }
+
+    getCharacterUrl(linkInfo) {
+        if (!linkInfo?.fullPath) return null;
+        const { folder, file } = splitCvPath(linkInfo.fullPath);
+        return `https://charavault.net/cards/preview/${encodeURIComponent(folder)}/${encodeURIComponent(file)}`;
+    }
+
+    openLinkUI(char) {
+        CoreAPI.openProviderLinkModal?.(char);
+    }
+
+    // ── Remote Data ─────────────────────────────────────────
+
+    async fetchMetadata(fullPath) {
+        const detail = await fetchCvCardDetail(fullPath);
+        return detail?.entry || null;
+    }
+
+    async fetchRemoteCard(linkInfo) {
+        const fullPath = linkInfo?.fullPath;
+        if (!fullPath) return null;
+        try {
+            const detail = await fetchCvCardDetail(fullPath);
+            if (!detail) return null;
+            const card = buildCvCharacterCard(detail, fullPath, null);
+            return card;
+        } catch (e) {
+            api?.debugLog?.('[CharaVaultProvider] fetchRemoteCard:', e.message);
+            return null;
+        }
+    }
+
+    async fetchLinkStats(linkInfo) {
+        const fullPath = linkInfo?.fullPath;
+        if (!fullPath) return null;
+        try {
+            const detail = await fetchCvCardDetail(fullPath);
+            const entry = detail?.entry;
+            if (!entry) return null;
+            _cachedLinkNode = entry;
+            return {
+                stat1: entry.avg_rating ? parseFloat(entry.avg_rating.toFixed(1)) : 0,
+                stat2: entry.rating_count || 0,
+                stat3: entry.token_count || 0,
+            };
+        } catch (e) {
+            api?.debugLog?.('[CharaVaultProvider] fetchLinkStats:', e.message);
+            return null;
+        }
+    }
+
+    get linkStatFields() {
+        return {
+            stat1: { icon: 'fa-solid fa-star', label: 'Avg Rating' },
+            stat2: { icon: 'fa-solid fa-users', label: 'Ratings' },
+            stat3: { icon: 'fa-solid fa-message', label: 'Tokens' },
+        };
+    }
+
+    getCachedLinkNode() { return _cachedLinkNode; }
+    clearCachedLinkNode() { _cachedLinkNode = null; }
+
+    // ── URL Handling ────────────────────────────────────────
+
+    canHandleUrl(url) {
+        if (!url) return false;
+        try {
+            const u = new URL(url.startsWith('http') ? url : `https://${url}`);
+            return /^(www\.)?charavault\.net$/i.test(u.hostname);
+        } catch {
+            return false;
+        }
+    }
+
+    parseUrl(url) {
+        if (!url) return null;
+        try {
+            const u = new URL(url.startsWith('http') ? url : `https://${url}`);
+            // Paths: /cards/preview/{folder}/{file} or /cards/{folder}/{file}
+            const match = u.pathname.match(/\/cards(?:\/(?:preview|thumb|download))?\/([^/]+)\/(.+)/);
+            if (match) return cvFullPath(match[1], match[2]);
+        } catch { /* ignore */ }
+        return null;
+    }
+
+    // ── Settings ────────────────────────────────────────────
+
+    getSettings() {
+        return [
+            {
+                key: 'charavaultGatewayUrl',
+                label: 'Gateway URL (optional)',
+                type: 'text',
+                defaultValue: '',
+                hint: 'Leave empty to talk to charavault.net directly. Only set this if you proxy CharaVault through your own gateway.',
+                section: 'CharaVault',
+            },
+            {
+                key: 'charavaultGatewayKey',
+                label: 'Gateway API Key (optional)',
+                type: 'password',
+                defaultValue: '',
+                hint: 'Bearer token sent to your gateway. Ignored when Gateway URL is empty.',
+                section: 'CharaVault',
+            },
+            {
+                key: 'charavaultAppPassword',
+                label: 'App Password',
+                type: 'password',
+                defaultValue: null,
+                hint: 'CharaVault app password (cv_...). Optional - required only for higher rate limits and downloads.',
+                section: 'CharaVault',
+            },
+        ];
+    }
+
+    // ── Bulk Linking ────────────────────────────────────────
+
+    get supportsBulkLink() { return true; }
+
+    openBulkLinkUI() {
+        CoreAPI.openBulkAutoLinkModal?.();
+    }
+
+    async searchForBulkLink(name, creator) {
+        try {
+            const results = [];
+
+            // Search by creator first if available (most precise)
+            if (creator && creator.trim()) {
+                const creatorData = await fetchCvCards({
+                    creator: creator.trim(),
+                    q: name,
+                    limit: 20,
+                    sort: 'most_downloaded',
+                });
+                for (const r of (creatorData.results || [])) {
+                    r.fullPath = cvFullPath(r.folder, r.file);
+                    results.push(this._normalizeSearchResult(r));
+                }
+                if (results.length > 0) return results;
+            }
+
+            // Name-only fallback
+            const data = await fetchCvCards({ q: name, limit: 15, sort: 'most_downloaded' });
+            for (const r of (data.results || [])) {
+                r.fullPath = cvFullPath(r.folder, r.file);
+                if (!results.some(x => x.fullPath === r.fullPath)) {
+                    results.push(this._normalizeSearchResult(r));
+                }
+            }
+            return results;
+        } catch (e) {
+            api?.debugLog?.('[CharaVaultProvider] searchForBulkLink:', e.message);
+            return [];
+        }
+    }
+
+    getResultAvatarUrl(result) {
+        const fp = result.fullPath || '';
+        const slash = fp.indexOf('/');
+        if (slash < 0) return '';
+        const folder = fp.slice(0, slash);
+        const file = fp.slice(slash + 1);
+        return cvThumbUrl(folder, file);
+    }
+
+    // ── Import Pipeline ─────────────────────────────────────
+
+    get supportsImport() { return true; }
+
+    /**
+     * Import a character from CharaVault by fullPath.
+     * Downloads the PNG card directly; the PNG already has the character
+     * data embedded, so we extract it, rebuild with our extension metadata,
+     * then re-embed and upload to SillyTavern.
+     */
+    async importCharacter(fullPath, hitData, options = {}) {
+        try {
+            const detail = await fetchCvCardDetail(fullPath);
+            if (!detail) throw new Error('Could not fetch character metadata');
+
+            // hitData is the search-list row passed from the browse modal -
+            // it carries `has_lorebook` which is missing from the detail entry.
+            const characterCard = buildCvCharacterCard(detail, fullPath, hitData);
+            const characterName = characterCard.data.name || fullPath.split('/').pop().replace(/\.png$/i, '');
+
+            assignGalleryId(characterCard, options, api);
+
+            const { folder, file } = splitCvPath(fullPath);
+            const pngUrl = cvDownloadUrl(folder, file);
+            let imageBuffer = null;
+            try {
+                const resp = await fetch(pngUrl, { headers: getCvHeaders() });
+                if (resp.ok) {
+                    imageBuffer = await resp.arrayBuffer();
+                }
+            } catch (e) {
+                api?.debugLog?.('[CharaVaultProvider] PNG download:', e.message);
+            }
+
+            // Fall back to thumbnail if PNG download failed
+            if (!imageBuffer) {
+                try {
+                    const thumbUrl = cvThumbUrl(folder, file);
+                    const resp = await fetch(thumbUrl, { headers: getCvHeaders() });
+                    if (resp.ok) imageBuffer = await resp.arrayBuffer();
+                } catch (e) {
+                    api?.debugLog?.('[CharaVaultProvider] thumb fallback:', e.message);
+                }
+            }
+
+            cvMetadataCache.delete(fullPath);
+
+            const result = await importFromPng({
+                characterCard,
+                imageBuffer,
+                fileName: `cv_${slugify(characterName)}.png`,
+                characterName,
+                hasGallery: false,
+                providerCharId: fullPath,
+                fullPath,
+                avatarUrl: cvThumbUrl(folder, file),
+                api,
+            });
+
+            if (result.success) {
+                markCvCardImported(fullPath);
+            }
+            return result;
+        } catch (e) {
+            api?.debugLog?.('[CharaVaultProvider] importCharacter:', e.message);
+            return { success: false, error: e.message };
+        }
+    }
+
+    // ── Import Duplicate Detection ──────────────────────────
+
+    async searchForImportMatch(name, creator) {
+        if (!name) return null;
+        try {
+            const results = await this.searchForBulkLink(name, creator || '');
+            if (results.length === 0) return null;
+            const norm = name.toLowerCase().trim();
+            for (const r of results) {
+                if ((r.name || '').toLowerCase().trim() === norm) {
+                    return { id: r.fullPath, fullPath: r.fullPath, hasGallery: false };
+                }
+            }
+            return { id: results[0].fullPath, fullPath: results[0].fullPath, hasGallery: false };
+        } catch (e) {
+            api?.debugLog?.('[CharaVaultProvider] searchForImportMatch:', e.message);
+            return null;
+        }
+    }
+
+    // ── Private ─────────────────────────────────────────────
+
+    _normalizeSearchResult(r) {
+        return {
+            id: r.fullPath,
+            fullPath: r.fullPath,
+            name: r.name || r.file || '',
+            avatarUrl: cvThumbUrl(r.folder || r.fullPath.split('/')[0], r.file || r.fullPath.split('/').pop()),
+            rating: r.avg_rating || 0,
+            starCount: r.rating_count || 0,
+            description: r.description_preview || '',
+            tagline: (r.tags || []).slice(0, 4).join(', '),
+            nTokens: r.token_count || 0,
+        };
+    }
+}
+
+const charavaultProvider = new CharaVaultProvider();
+export default charavaultProvider;

--- a/modules/providers/chartavern/chartavern-api.js
+++ b/modules/providers/chartavern/chartavern-api.js
@@ -80,6 +80,20 @@ export const CT_SORT_OPTIONS = {
 import { fetchWithProxy } from '../provider-utils.js';
 export { fetchWithProxy };
 
+/**
+ * Build outgoing headers for a CharacterTavern request. When the user
+ * configures a gateway URL + key, the key is sent as Authorization so
+ * the gateway can authenticate the call. Direct (default) requests to
+ * character-tavern.com need no auth header.
+ * @returns {Object}
+ */
+export function getCtHeaders() {
+    const headers = { 'Accept': 'application/json' };
+    const gwKey = _getSetting?.('chartavernGatewayKey');
+    if (gwKey) headers['Authorization'] = `Bearer ${gwKey}`;
+    return headers;
+}
+
 // ========================================
 // AUTH - cl-helper cookie session
 // ========================================
@@ -196,7 +210,7 @@ async function ctFetch(url, apiRequest) {
         const resp = await apiRequest(`${CL_HELPER_CT_BASE}/ct-proxy${path}`);
         return resp;
     }
-    return fetchWithProxy(url);
+    return fetchWithProxy(url, { headers: getCtHeaders() });
 }
 
 // ========================================
@@ -273,7 +287,7 @@ export async function fetchCharacterDetail(author, slug, apiRequest) {
  */
 export async function fetchTopTags() {
     const url = `${getCtApiBase()}/catalog/top-tags`;
-    const resp = await fetchWithProxy(url);
+    const resp = await fetchWithProxy(url, { headers: getCtHeaders() });
     if (!resp.ok) throw new Error(`Top tags fetch failed (${resp.status})`);
     return resp.json();
 }

--- a/modules/providers/chartavern/chartavern-api.js
+++ b/modules/providers/chartavern/chartavern-api.js
@@ -10,9 +10,59 @@
 import { CL_HELPER_PLUGIN_BASE as CL_HELPER_CT_BASE } from '../provider-utils.js';
 export { CL_HELPER_CT_BASE };
 
-export const CT_API_BASE = 'https://character-tavern.com/api';
-export const CT_SITE_BASE = 'https://character-tavern.com';
-export const CT_CARDS_CDN = 'https://cards.character-tavern.com';
+let _getSetting = null;
+
+/**
+ * Must be called once before any other export is used.
+ * @param {{ getSetting: Function }} deps
+ */
+export function initChartavernApi(deps) {
+    _getSetting = deps.getSetting;
+}
+
+// Default upstream hosts. CharacterTavern has three: the REST API, the
+// public site (favicons, og:images), and the cards CDN.
+const CT_DEFAULT_API   = 'https://character-tavern.com/api';
+const CT_DEFAULT_SITE  = 'https://character-tavern.com';
+const CT_DEFAULT_CDN   = 'https://cards.character-tavern.com';
+
+// When proxying through a self-hosted gateway, the convention below
+// mirrors the gateway used by this extension upstream. A reverse proxy
+// that exposes these paths gets the simple single-field setup; per-host
+// overrides remain available for non-standard topologies.
+const CT_GATEWAY_PATHS = {
+    api:  '/v1/ct',
+    site: '/v1/ct-site',
+    cdn:  '/v1/ct-cdn',
+};
+
+function _trimSlash(s) {
+    return s.replace(/\/+$/, '');
+}
+
+function _resolveCtBase(overrideKey, defaultBase, gatewayPath) {
+    const override = _trimSlash((_getSetting?.(overrideKey) || '').trim());
+    if (override) return override;
+    const base = _trimSlash((_getSetting?.('chartavernGatewayBaseUrl') || '').trim());
+    if (base) return base + gatewayPath;
+    return defaultBase;
+}
+
+export function getCtApiBase() {
+    return _resolveCtBase('chartavernGatewayApiUrl', CT_DEFAULT_API, CT_GATEWAY_PATHS.api);
+}
+
+export function getCtSiteBase() {
+    return _resolveCtBase('chartavernGatewaySiteUrl', CT_DEFAULT_SITE, CT_GATEWAY_PATHS.site);
+}
+
+export function getCtCardsCdn() {
+    return _resolveCtBase('chartavernGatewayCdnUrl', CT_DEFAULT_CDN, CT_GATEWAY_PATHS.cdn);
+}
+
+export function getCtGatewayKey() {
+    return _getSetting?.('chartavernGatewayKey') || '';
+}
 
 // Sort options accepted by /api/search/cards
 export const CT_SORT_OPTIONS = {
@@ -142,7 +192,7 @@ export function isCtSessionActive() {
 async function ctFetch(url, apiRequest) {
     if (ctSessionActive && apiRequest) {
         // Route through cl-helper proxy: strip the CT origin, prepend proxy path
-        const path = url.replace(CT_SITE_BASE, '');
+        const path = url.replace(getCtSiteBase(), '');
         const resp = await apiRequest(`${CL_HELPER_CT_BASE}/ct-proxy${path}`);
         return resp;
     }
@@ -193,7 +243,7 @@ export async function searchCards(opts = {}, apiRequest) {
         params.set('exclude_tags', existing.join(','));
     }
 
-    const url = `${CT_API_BASE}/search/cards?${params}`;
+    const url = `${getCtApiBase()}/search/cards?${params}`;
     const resp = await ctFetch(url, apiRequest);
     if (!resp.ok) {
         throw new Error(`CT search returned HTTP ${resp.status}`);
@@ -209,7 +259,7 @@ export async function searchCards(opts = {}, apiRequest) {
  * @returns {Promise<Object>} { card: {...}, ownerCTId: ... }
  */
 export async function fetchCharacterDetail(author, slug, apiRequest) {
-    const url = `${CT_API_BASE}/character/${encodeURIComponent(author)}/${encodeURIComponent(slug)}`;
+    const url = `${getCtApiBase()}/character/${encodeURIComponent(author)}/${encodeURIComponent(slug)}`;
     const resp = await ctFetch(url, apiRequest);
     if (!resp.ok) {
         throw new Error(`CT detail returned HTTP ${resp.status}`);
@@ -222,7 +272,7 @@ export async function fetchCharacterDetail(author, slug, apiRequest) {
  * @returns {Promise<Array<{tag: string, count: number}>>}
  */
 export async function fetchTopTags() {
-    const url = `${CT_API_BASE}/catalog/top-tags`;
+    const url = `${getCtApiBase()}/catalog/top-tags`;
     const resp = await fetchWithProxy(url);
     if (!resp.ok) throw new Error(`Top tags fetch failed (${resp.status})`);
     return resp.json();
@@ -239,7 +289,7 @@ export async function fetchTopTags() {
  * @returns {string}
  */
 export function getAvatarUrl(path, width = 320) {
-    return `${CT_CARDS_CDN}/cdn-cgi/image/format=auto,width=${width},quality=85/${path}.png`;
+    return `${getCtCardsCdn()}/cdn-cgi/image/format=auto,width=${width},quality=85/${path}.png`;
 }
 
 /**
@@ -248,7 +298,7 @@ export function getAvatarUrl(path, width = 320) {
  * @returns {string}
  */
 export function getCardPngUrl(path) {
-    return `${CT_CARDS_CDN}/${path}.png`;
+    return `${getCtCardsCdn()}/${path}.png`;
 }
 
 /**
@@ -257,7 +307,7 @@ export function getCardPngUrl(path) {
  * @returns {string}
  */
 export function getCharacterPageUrl(path) {
-    return `${CT_SITE_BASE}/character/${path}`;
+    return `${getCtSiteBase()}/character/${path}`;
 }
 
 /**

--- a/modules/providers/chartavern/chartavern-provider.js
+++ b/modules/providers/chartavern/chartavern-provider.js
@@ -8,7 +8,6 @@ import CoreAPI from '../../core-api.js';
 import { assignGalleryId, importFromPng } from '../provider-utils.js';
 import chartavernBrowseView from './chartavern-browse.js';
 import {
-    CT_SITE_BASE,
     fetchWithProxy,
     searchCards,
     fetchCharacterDetail,
@@ -23,6 +22,8 @@ import {
     isCtSessionActive,
     ctSetCookie,
     ctValidateSession,
+    initChartavernApi,
+    getCtSiteBase,
 } from './chartavern-api.js';
 
 let api = null;
@@ -117,7 +118,7 @@ class ChartavernProvider extends ProviderBase {
     get id() { return 'chartavern'; }
     get name() { return 'CharacterTavern'; }
     get icon() { return 'fa-solid fa-beer-mug-empty'; }
-    get iconUrl() { return `${CT_SITE_BASE}/favicon.ico`; }
+    get iconUrl() { return `${getCtSiteBase()}/favicon.ico`; }
     get browseView() { return chartavernBrowseView; }
 
     get linkStatFields() {
@@ -132,6 +133,7 @@ class ChartavernProvider extends ProviderBase {
 
     async init(coreAPI) {
         super.init(coreAPI);
+        initChartavernApi({ getSetting: coreAPI.getSetting });
         api = coreAPI;
     }
 

--- a/modules/providers/chub/chub-api.js
+++ b/modules/providers/chub/chub-api.js
@@ -8,9 +8,49 @@
 // CONSTANTS
 // ========================================
 
-export const CHUB_API_BASE = 'https://api.chub.ai';
-export const CHUB_GATEWAY_BASE = 'https://gateway.chub.ai';
-export const CHUB_AVATAR_BASE = 'https://avatars.charhub.io/avatars/';
+// Default upstream hosts. ChubAI splits across three of them:
+//   api.chub.ai           - REST API
+//   gateway.chub.ai       - GraphQL gateway / favorites / gallery
+//   avatars.charhub.io    - public CDN for avatars and card PNGs
+const CHUB_DEFAULT_API     = 'https://api.chub.ai';
+const CHUB_DEFAULT_GATEWAY = 'https://gateway.chub.ai';
+const CHUB_DEFAULT_AVATAR  = 'https://avatars.charhub.io/avatars/';
+
+// When the user runs ChubAI through their own gateway, only one base URL
+// is usually needed. The convention below mirrors the gateway used by
+// this extension upstream (`/v1/chub`, `/v1/chub-gw`, `/v1/chub-av`); a
+// reverse proxy that uses these paths gets the simple single-field setup.
+// Per-host overrides are still available for non-standard topologies.
+const CHUB_GATEWAY_PATHS = {
+    api:    '/v1/chub',
+    gw:     '/v1/chub-gw',
+    avatar: '/v1/chub-av/avatars/',
+};
+
+function _trimSlash(s) {
+    return s.replace(/\/+$/, '');
+}
+
+function _resolveChubBase(overrideKey, defaultBase, gatewayPath) {
+    const override = _trimSlash((_getSetting?.(overrideKey) || '').trim());
+    if (override) return override;
+    const base = _trimSlash((_getSetting?.('chubGatewayBaseUrl') || '').trim());
+    if (base) return base + gatewayPath;
+    return defaultBase;
+}
+
+export function getChubApiBase() {
+    return _resolveChubBase('chubGatewayApiUrl', CHUB_DEFAULT_API, CHUB_GATEWAY_PATHS.api);
+}
+
+export function getChubGatewayBase() {
+    return _resolveChubBase('chubGatewayGatewayUrl', CHUB_DEFAULT_GATEWAY, CHUB_GATEWAY_PATHS.gw);
+}
+
+export function getChubAvatarBase() {
+    const base = _resolveChubBase('chubGatewayAvatarUrl', CHUB_DEFAULT_AVATAR, CHUB_GATEWAY_PATHS.avatar);
+    return base.endsWith('/') ? base : base + '/';
+}
 
 // ========================================
 // INITIALIZATION
@@ -44,9 +84,17 @@ function debugLog(...args) {
  */
 export function getChubHeaders(includeAuth = true) {
     const headers = { 'Accept': 'application/json' };
+    const gwKey = _getSetting?.('chubGatewayKey');
+    if (gwKey) headers['Authorization'] = `Bearer ${gwKey}`;
     const token = _getSetting?.('chubToken');
-    if (includeAuth && token) {
+    if (includeAuth && token && !gwKey) {
+        // chub.ai user token only when not going through a custom gateway
+        // (the gateway is expected to handle upstream auth itself).
         headers['Authorization'] = `Bearer ${token}`;
+    } else if (includeAuth && token && gwKey) {
+        // Both set: gateway key in Authorization, chub token forwarded
+        // separately so the gateway can re-attach it upstream.
+        headers['X-Chub-Token'] = token;
     }
     return headers;
 }
@@ -95,7 +143,7 @@ export async function fetchChubMetadata(fullPath) {
     }
 
     try {
-        const url = `${CHUB_API_BASE}/api/characters/${fullPath}?full=true`;
+        const url = `${getChubApiBase()}/api/characters/${fullPath}?full=true`;
         debugLog('[Chub] Fetching metadata from:', url);
 
         let response;
@@ -186,7 +234,7 @@ export async function fetchChubLinkedLorebook(projectId) {
     if (!projectId) return null;
     const headers = getChubHeaders(true);
     try {
-        const commitsUrl = `${CHUB_API_BASE}/api/v4/projects/${projectId}/repository/commits`;
+        const commitsUrl = `${getChubApiBase()}/api/v4/projects/${projectId}/repository/commits`;
         let commitsResp;
         try {
             commitsResp = await fetch(commitsUrl, { headers });
@@ -199,7 +247,7 @@ export async function fetchChubLinkedLorebook(projectId) {
         const ref = Array.isArray(commits) && commits[0]?.id;
         if (!ref) return null;
 
-        const cardUrl = `${CHUB_API_BASE}/api/v4/projects/${projectId}/repository/files/raw%252Fcard.json/raw?ref=${ref}`;
+        const cardUrl = `${getChubApiBase()}/api/v4/projects/${projectId}/repository/files/raw%252Fcard.json/raw?ref=${ref}`;
         let cardResp;
         try {
             cardResp = await fetch(cardUrl, { headers });

--- a/modules/providers/chub/chub-browse.js
+++ b/modules/providers/chub/chub-browse.js
@@ -2,7 +2,7 @@
 
 import { BrowseView } from '../browse-view.js';
 import CoreAPI from '../../core-api.js';
-import { IMG_PLACEHOLDER, formatNumber } from '../provider-utils.js';
+import { IMG_PLACEHOLDER, formatNumber, fetchWithProxy } from '../provider-utils.js';
 import {
     CHUB_API_BASE,
     CHUB_GATEWAY_BASE,
@@ -264,7 +264,7 @@ class ChubBrowseView extends BrowseView {
         }
 
         try {
-            const response = await fetch(`${CHUB_API_BASE}/api/follow/${username}`, {
+            const response = await fetchWithProxy(`${CHUB_API_BASE}/api/follow/${username}`, {
                 method: 'POST',
                 headers: { ...getChubHeaders(true), 'Content-Type': 'application/json' },
             });
@@ -282,7 +282,7 @@ class ChubBrowseView extends BrowseView {
     async unfollowCreator(id) {
         if (!chubToken) return false;
         try {
-            const response = await fetch(`${CHUB_API_BASE}/api/follow/${id}`, {
+            const response = await fetchWithProxy(`${CHUB_API_BASE}/api/follow/${id}`, {
                 method: 'DELETE',
                 headers: getChubHeaders(true),
             });
@@ -1426,7 +1426,7 @@ async function fetchChubPopularTags() {
                         min_tokens: '50'
                     });
                     
-                    const response = await fetch(`${CHUB_API_BASE}/search?${params.toString()}`, {
+                    const response = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
                         method: 'GET',
                         headers
                     });
@@ -1976,7 +1976,7 @@ async function loadChubTimeline(forceRefresh = false, _isAutoPage = false, _appe
         
         debugLog('[ChubTimeline] Loading timeline, nsfw:', chubNsfwEnabled);
         
-        const response = await fetch(`${CHUB_API_BASE}/api/timeline/v1?${params.toString()}`, {
+        const response = await fetchWithProxy(`${CHUB_API_BASE}/api/timeline/v1?${params.toString()}`, {
             method: 'GET',
             headers
         });
@@ -2180,7 +2180,7 @@ async function supplementTimelineWithAuthorFetches(page = 1) {
                     params.set('nsfl', chubNsfwEnabled.toString());
                     params.set('include_forks', 'true');
                     
-                    const response = await fetch(`${CHUB_API_BASE}/search?${params.toString()}`, {
+                    const response = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
                         headers: getChubHeaders(true)
                     });
                     
@@ -2526,7 +2526,7 @@ async function fetchMyFollowsList(forceRefresh = false) {
     
     try {
         // First get our own username from account
-        const accountResp = await fetch(`${CHUB_API_BASE}/api/account`, {
+        const accountResp = await fetchWithProxy(`${CHUB_API_BASE}/api/account`, {
             headers: getChubHeaders(true)
         });
         
@@ -2547,7 +2547,7 @@ async function fetchMyFollowsList(forceRefresh = false) {
         }
         
         // Now get who we follow
-        const followsResp = await fetch(`${CHUB_API_BASE}/api/follows/${myUsername}?page=1`, {
+        const followsResp = await fetchWithProxy(`${CHUB_API_BASE}/api/follows/${myUsername}?page=1`, {
             headers: getChubHeaders(true)
         });
         
@@ -2575,7 +2575,7 @@ async function fetchMyFollowsList(forceRefresh = false) {
         const totalCount = followsData.count || 0;
         let page = 2;
         while (followedUsernames.size < totalCount && page <= 20) {
-            const moreResp = await fetch(`${CHUB_API_BASE}/api/follows/${myUsername}?page=${page}`, {
+            const moreResp = await fetchWithProxy(`${CHUB_API_BASE}/api/follows/${myUsername}?page=${page}`, {
                 headers: getChubHeaders(true)
             });
             
@@ -2665,7 +2665,7 @@ async function toggleFollowAuthor() {
         const headers = getChubHeaders(true);
         headers['Content-Type'] = 'application/json';
         
-        const response = await fetch(`${CHUB_API_BASE}/api/follow/${chubAuthorFilter}`, {
+        const response = await fetchWithProxy(`${CHUB_API_BASE}/api/follow/${chubAuthorFilter}`, {
             method: method,
             headers
         });
@@ -2879,7 +2879,7 @@ async function loadChubCharacters(forceRefresh = false) {
         
         const headers = getChubHeaders(true);
         
-        const response = await fetch(`${CHUB_API_BASE}/search?${params.toString()}`, {
+        const response = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
             method: 'GET',
             headers
         });
@@ -2948,7 +2948,7 @@ async function loadChubCharacters(forceRefresh = false) {
                 chubCurrentPage++;
                 params.set('page', chubCurrentPage.toString());
                 
-                const moreRes = await fetch(`${CHUB_API_BASE}/search?${params.toString()}`, {
+                const moreRes = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
                     method: 'GET',
                     headers
                 });
@@ -3275,7 +3275,7 @@ function createChubCard(char, isTimeline = false) {
     // ChubAI's weird naming: starCount is actually downloads, n_favorites is the heart/favorite count
     const downloads = formatNumber(char.starCount || 0);
     const favorites = formatNumber(char.n_favorites || char.nFavorites || 0);
-    const avatarUrl = char.avatar_url || (fullPath ? `https://avatars.charhub.io/avatars/${fullPath}/avatar.webp` : '/img/ai4.png');
+    const avatarUrl = char.avatar_url || (fullPath ? `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp` : '/img/ai4.png');
     
     // Check if this character is in local library
     const inLibrary = isCharInLocalLibrary(char);
@@ -3456,7 +3456,7 @@ async function openChubCharPreview(char) {
     const galleryLabel = document.getElementById('chubCharGalleryLabel');
     
     const fullPath = getChubFullPath(char);
-    const avatarUrl = char.avatar_url || (fullPath ? `https://avatars.charhub.io/avatars/${fullPath}/avatar.webp` : '/img/ai4.png');
+    const avatarUrl = char.avatar_url || (fullPath ? `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp` : '/img/ai4.png');
     const creatorName = fullPath.split('/')[0] || 'Unknown';
     const inLibrary = isCharInLocalLibrary(char);
     const possibleMatch = !inLibrary && view.isCharPossibleMatch(char.name || '', creatorName);

--- a/modules/providers/chub/chub-browse.js
+++ b/modules/providers/chub/chub-browse.js
@@ -4,9 +4,9 @@ import { BrowseView } from '../browse-view.js';
 import CoreAPI from '../../core-api.js';
 import { IMG_PLACEHOLDER, formatNumber, fetchWithProxy } from '../provider-utils.js';
 import {
-    CHUB_API_BASE,
-    CHUB_GATEWAY_BASE,
-    CHUB_AVATAR_BASE,
+    getChubApiBase,
+    getChubGatewayBase,
+    getChubAvatarBase,
     getChubHeaders,
     extractNodes,
 } from './chub-api.js';
@@ -247,7 +247,7 @@ class ChubBrowseView extends BrowseView {
         if (creator.avatar) return creator.avatar;
         const fp = chubTimelineCharacters.find(c =>
             (c.fullPath || c.full_path || '').toLowerCase().startsWith(creator.id + '/'));
-        return fp ? `${CHUB_AVATAR_BASE}${fp.fullPath || fp.full_path}/avatar.webp` : '';
+        return fp ? `${getChubAvatarBase()}${fp.fullPath || fp.full_path}/avatar.webp` : '';
     }
 
     async followCreator(query) {
@@ -264,7 +264,7 @@ class ChubBrowseView extends BrowseView {
         }
 
         try {
-            const response = await fetchWithProxy(`${CHUB_API_BASE}/api/follow/${username}`, {
+            const response = await fetchWithProxy(`${getChubApiBase()}/api/follow/${username}`, {
                 method: 'POST',
                 headers: { ...getChubHeaders(true), 'Content-Type': 'application/json' },
             });
@@ -282,7 +282,7 @@ class ChubBrowseView extends BrowseView {
     async unfollowCreator(id) {
         if (!chubToken) return false;
         try {
-            const response = await fetchWithProxy(`${CHUB_API_BASE}/api/follow/${id}`, {
+            const response = await fetchWithProxy(`${getChubApiBase()}/api/follow/${id}`, {
                 method: 'DELETE',
                 headers: getChubHeaders(true),
             });
@@ -1426,7 +1426,7 @@ async function fetchChubPopularTags() {
                         min_tokens: '50'
                     });
                     
-                    const response = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
+                    const response = await fetchWithProxy(`${getChubApiBase()}/search?${params.toString()}`, {
                         method: 'GET',
                         headers
                     });
@@ -1976,7 +1976,7 @@ async function loadChubTimeline(forceRefresh = false, _isAutoPage = false, _appe
         
         debugLog('[ChubTimeline] Loading timeline, nsfw:', chubNsfwEnabled);
         
-        const response = await fetchWithProxy(`${CHUB_API_BASE}/api/timeline/v1?${params.toString()}`, {
+        const response = await fetchWithProxy(`${getChubApiBase()}/api/timeline/v1?${params.toString()}`, {
             method: 'GET',
             headers
         });
@@ -2180,7 +2180,7 @@ async function supplementTimelineWithAuthorFetches(page = 1) {
                     params.set('nsfl', chubNsfwEnabled.toString());
                     params.set('include_forks', 'true');
                     
-                    const response = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
+                    const response = await fetchWithProxy(`${getChubApiBase()}/search?${params.toString()}`, {
                         headers: getChubHeaders(true)
                     });
                     
@@ -2526,7 +2526,7 @@ async function fetchMyFollowsList(forceRefresh = false) {
     
     try {
         // First get our own username from account
-        const accountResp = await fetchWithProxy(`${CHUB_API_BASE}/api/account`, {
+        const accountResp = await fetchWithProxy(`${getChubApiBase()}/api/account`, {
             headers: getChubHeaders(true)
         });
         
@@ -2547,7 +2547,7 @@ async function fetchMyFollowsList(forceRefresh = false) {
         }
         
         // Now get who we follow
-        const followsResp = await fetchWithProxy(`${CHUB_API_BASE}/api/follows/${myUsername}?page=1`, {
+        const followsResp = await fetchWithProxy(`${getChubApiBase()}/api/follows/${myUsername}?page=1`, {
             headers: getChubHeaders(true)
         });
         
@@ -2575,7 +2575,7 @@ async function fetchMyFollowsList(forceRefresh = false) {
         const totalCount = followsData.count || 0;
         let page = 2;
         while (followedUsernames.size < totalCount && page <= 20) {
-            const moreResp = await fetchWithProxy(`${CHUB_API_BASE}/api/follows/${myUsername}?page=${page}`, {
+            const moreResp = await fetchWithProxy(`${getChubApiBase()}/api/follows/${myUsername}?page=${page}`, {
                 headers: getChubHeaders(true)
             });
             
@@ -2665,7 +2665,7 @@ async function toggleFollowAuthor() {
         const headers = getChubHeaders(true);
         headers['Content-Type'] = 'application/json';
         
-        const response = await fetchWithProxy(`${CHUB_API_BASE}/api/follow/${chubAuthorFilter}`, {
+        const response = await fetchWithProxy(`${getChubApiBase()}/api/follow/${chubAuthorFilter}`, {
             method: method,
             headers
         });
@@ -2879,7 +2879,7 @@ async function loadChubCharacters(forceRefresh = false) {
         
         const headers = getChubHeaders(true);
         
-        const response = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
+        const response = await fetchWithProxy(`${getChubApiBase()}/search?${params.toString()}`, {
             method: 'GET',
             headers
         });
@@ -2948,7 +2948,7 @@ async function loadChubCharacters(forceRefresh = false) {
                 chubCurrentPage++;
                 params.set('page', chubCurrentPage.toString());
                 
-                const moreRes = await fetchWithProxy(`${CHUB_API_BASE}/search?${params.toString()}`, {
+                const moreRes = await fetchWithProxy(`${getChubApiBase()}/search?${params.toString()}`, {
                     method: 'GET',
                     headers
                 });
@@ -3022,7 +3022,7 @@ async function fetchChubUserFavoriteIds() {
     }
     
     try {
-        const url = `${CHUB_GATEWAY_BASE}/api/favorites?first=500`;
+        const url = `${getChubGatewayBase()}/api/favorites?first=500`;
         const response = await fetch(url, {
             method: 'GET',
             headers: {
@@ -3066,7 +3066,7 @@ async function loadChubFavorites(forceRefresh = false, loadToken = 0) {
             params.set('page', chubCurrentPage.toString());
         }
         
-        const url = `${CHUB_GATEWAY_BASE}/api/favorites?${params.toString()}`;
+        const url = `${getChubGatewayBase()}/api/favorites?${params.toString()}`;
         debugLog('[ChubAI] Loading favorites from:', url);
         
         const response = await fetch(url, {
@@ -3275,7 +3275,7 @@ function createChubCard(char, isTimeline = false) {
     // ChubAI's weird naming: starCount is actually downloads, n_favorites is the heart/favorite count
     const downloads = formatNumber(char.starCount || 0);
     const favorites = formatNumber(char.n_favorites || char.nFavorites || 0);
-    const avatarUrl = char.avatar_url || (fullPath ? `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp` : '/img/ai4.png');
+    const avatarUrl = char.avatar_url || (fullPath ? `${getChubAvatarBase()}${fullPath}/avatar.webp` : '/img/ai4.png');
     
     // Check if this character is in local library
     const inLibrary = isCharInLocalLibrary(char);
@@ -3456,7 +3456,7 @@ async function openChubCharPreview(char) {
     const galleryLabel = document.getElementById('chubCharGalleryLabel');
     
     const fullPath = getChubFullPath(char);
-    const avatarUrl = char.avatar_url || (fullPath ? `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp` : '/img/ai4.png');
+    const avatarUrl = char.avatar_url || (fullPath ? `${getChubAvatarBase()}${fullPath}/avatar.webp` : '/img/ai4.png');
     const creatorName = fullPath.split('/')[0] || 'Unknown';
     const inLibrary = isCharInLocalLibrary(char);
     const possibleMatch = !inLibrary && view.isCharPossibleMatch(char.name || '', creatorName);
@@ -3724,7 +3724,7 @@ async function openChubCharPreview(char) {
             }
             const charProjectId = char.id || char.project_id;
             const galleryPromise = char.hasGallery && charProjectId
-                ? fetch(`${CHUB_GATEWAY_BASE}/api/gallery/project/${charProjectId}?limit=100&count=false`, {
+                ? fetch(`${getChubGatewayBase()}/api/gallery/project/${charProjectId}?limit=100&count=false`, {
                     headers: galleryHeaders, signal: fetchSignal
                 }).then(r => {
                     if (r.ok) return r.json();
@@ -3833,7 +3833,7 @@ async function updateChubFavoriteButton(char) {
         
         // Try to get user's favorites list and check if this char is in it
         // The gateway endpoint might not support GET for single item, so we check differently
-        const url = `${CHUB_GATEWAY_BASE}/api/favorites?first=500`;
+        const url = `${getChubGatewayBase()}/api/favorites?first=500`;
         debugLog('[ChubAI] Checking favorites list for:', charId);
         
         const response = await fetch(url, {
@@ -3910,7 +3910,7 @@ async function toggleChubCharFavorite() {
     favoriteBtn.classList.add('loading');
     
     try {
-        const url = `${CHUB_GATEWAY_BASE}/api/favorites/${charId}`;
+        const url = `${getChubGatewayBase()}/api/favorites/${charId}`;
         debugLog('[ChubAI] Toggle favorite:', isCurrentlyFavorited ? 'DELETE' : 'POST', url);
         
         const response = await fetch(url, {
@@ -4048,7 +4048,7 @@ async function downloadChubCharacter() {
                 name: characterName,
                 creator: characterCreator,
                 fullPath: fullPath,
-                avatarUrl: chubSelectedChar.avatar_url || `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp`
+                avatarUrl: chubSelectedChar.avatar_url || `${getChubAvatarBase()}${fullPath}/avatar.webp`
             }, duplicateMatches);
             
             if (result.choice === 'skip') {

--- a/modules/providers/chub/chub-provider.js
+++ b/modules/providers/chub/chub-provider.js
@@ -193,7 +193,7 @@ class ChubProvider extends ProviderBase {
             name: metadata.name || metadata.definition?.name,
             description: metadata.description,
             tagline: metadata.tagline,
-            avatar_url: `https://avatars.charhub.io/avatars/${linkInfo.fullPath}/avatar.webp`,
+            avatar_url: `${CHUB_AVATAR_BASE}${linkInfo.fullPath}/avatar.webp`,
             rating: metadata.rating,
             ratingCount: metadata.ratingCount || metadata.rating_count,
             starCount: metadata.starCount || metadata.star_count,
@@ -619,7 +619,7 @@ class ChubProvider extends ProviderBase {
                     username: creatorLower
                 });
                 try {
-                    const authorResp = await fetch(`${CHUB_API_BASE}/search?${authorParams}`, { method: 'GET', headers });
+                    const authorResp = await fetchWithProxy(`${CHUB_API_BASE}/search?${authorParams}`, { method: 'GET', headers });
                     if (authorResp.ok) {
                         const authorData = await authorResp.json();
                         const authorNodes = this._extractNodes(authorData);
@@ -650,7 +650,7 @@ class ChubProvider extends ProviderBase {
                 search: searchTerm, first: '10', sort: 'download_count',
                 nsfw: 'true', nsfl: 'true', include_forks: 'true', min_tokens: '50'
             });
-            const resp = await fetch(`${CHUB_API_BASE}/search?${params}`, { method: 'GET', headers });
+            const resp = await fetchWithProxy(`${CHUB_API_BASE}/search?${params}`, { method: 'GET', headers });
             if (resp.ok) {
                 const data = await resp.json();
                 for (const node of this._extractNodes(data)) {
@@ -666,7 +666,7 @@ class ChubProvider extends ProviderBase {
                     search: name, first: '15', sort: 'download_count',
                     nsfw: 'true', nsfl: 'true', include_forks: 'true', min_tokens: '50'
                 });
-                const nameResp = await fetch(`${CHUB_API_BASE}/search?${nameParams}`, { method: 'GET', headers });
+                const nameResp = await fetchWithProxy(`${CHUB_API_BASE}/search?${nameParams}`, { method: 'GET', headers });
                 if (nameResp.ok) {
                     const nameData = await nameResp.json();
                     allResults = this._extractNodes(nameData).map(n => this._normalizeSearchResult(n, CHUB_AVATAR_BASE));

--- a/modules/providers/chub/chub-provider.js
+++ b/modules/providers/chub/chub-provider.js
@@ -9,9 +9,9 @@ import { assignGalleryId, importFromPng, slugify } from '../provider-utils.js';
 import chubBrowseView, { openChubTokenModal } from './chub-browse.js';
 import {
     initChubApi,
-    CHUB_API_BASE,
-    CHUB_GATEWAY_BASE,
-    CHUB_AVATAR_BASE,
+    getChubApiBase,
+    getChubGatewayBase,
+    getChubAvatarBase,
     fetchWithProxy,
     extractNodes,
     chubMetadataCache,
@@ -193,7 +193,7 @@ class ChubProvider extends ProviderBase {
             name: metadata.name || metadata.definition?.name,
             description: metadata.description,
             tagline: metadata.tagline,
-            avatar_url: `${CHUB_AVATAR_BASE}${linkInfo.fullPath}/avatar.webp`,
+            avatar_url: `${getChubAvatarBase()}${linkInfo.fullPath}/avatar.webp`,
             rating: metadata.rating,
             ratingCount: metadata.ratingCount || metadata.rating_count,
             starCount: metadata.starCount || metadata.star_count,
@@ -232,7 +232,7 @@ class ChubProvider extends ProviderBase {
                 charId: ext.id || null,
                 fullPath: fullPath || null,
                 hasGallery: !!ext.id,
-                avatarUrl: fullPath ? `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp` : null
+                avatarUrl: fullPath ? `${getChubAvatarBase()}${fullPath}/avatar.webp` : null
             }
         };
     }
@@ -293,7 +293,7 @@ class ChubProvider extends ProviderBase {
             }
 
             // Last resort: PNG extraction
-            const pngUrl = `${CHUB_AVATAR_BASE}${fullPath}/chara_card_v2.png`;
+            const pngUrl = `${getChubAvatarBase()}${fullPath}/chara_card_v2.png`;
             let response;
             try { response = await fetch(pngUrl); }
             catch { response = await fetch(`/proxy/${encodeURIComponent(pngUrl)}`); }
@@ -330,7 +330,7 @@ class ChubProvider extends ProviderBase {
         const fullPath = linkInfo?.fullPath;
         if (!fullPath) return null;
         try {
-            const url = `${CHUB_API_BASE}/api/characters/${fullPath}?full=true`;
+            const url = `${getChubApiBase()}/api/characters/${fullPath}?full=true`;
             const response = await fetchWithProxy(url, { headers: this._getHeaders() });
             const data = await response.json();
             const node = data.node;
@@ -401,7 +401,7 @@ class ChubProvider extends ProviderBase {
         if (!id) return [];
 
         const r = await fetchWithProxy(
-            `${CHUB_API_BASE}/api/v4/projects/${id}/repository/commits`,
+            `${getChubApiBase()}/api/v4/projects/${id}/repository/commits`,
             { headers: this._getHeaders() }
         );
         const commits = await r.json();
@@ -428,7 +428,7 @@ class ChubProvider extends ProviderBase {
             await this._getProjectId(fullPath);
         }
         if (!_projectId) return null;
-        const url = `${CHUB_API_BASE}/api/v4/projects/${_projectId}/repository/files/raw%252Fcard.json/raw?ref=${ref}`;
+        const url = `${getChubApiBase()}/api/v4/projects/${_projectId}/repository/files/raw%252Fcard.json/raw?ref=${ref}`;
         try {
             const r = await fetchWithProxy(url, { headers: this._getHeaders() });
             const d = await r.json();
@@ -619,7 +619,7 @@ class ChubProvider extends ProviderBase {
                     username: creatorLower
                 });
                 try {
-                    const authorResp = await fetchWithProxy(`${CHUB_API_BASE}/search?${authorParams}`, { method: 'GET', headers });
+                    const authorResp = await fetchWithProxy(`${getChubApiBase()}/search?${authorParams}`, { method: 'GET', headers });
                     if (authorResp.ok) {
                         const authorData = await authorResp.json();
                         const authorNodes = this._extractNodes(authorData);
@@ -631,7 +631,7 @@ class ChubProvider extends ProviderBase {
                             const anyWordMatch = nameWords.some(w => nodeName.includes(w));
                             if (nodeName === normalizedName || nodeName.includes(normalizedName) ||
                                 normalizedName.includes(nodeName) || firstWordMatch || anyWordMatch) {
-                                allResults.push(this._normalizeSearchResult(node, CHUB_AVATAR_BASE));
+                                allResults.push(this._normalizeSearchResult(node, getChubAvatarBase()));
                             }
                         }
                         if (allResults.length > 0) {
@@ -650,12 +650,12 @@ class ChubProvider extends ProviderBase {
                 search: searchTerm, first: '10', sort: 'download_count',
                 nsfw: 'true', nsfl: 'true', include_forks: 'true', min_tokens: '50'
             });
-            const resp = await fetchWithProxy(`${CHUB_API_BASE}/search?${params}`, { method: 'GET', headers });
+            const resp = await fetchWithProxy(`${getChubApiBase()}/search?${params}`, { method: 'GET', headers });
             if (resp.ok) {
                 const data = await resp.json();
                 for (const node of this._extractNodes(data)) {
                     if (!allResults.some(r => r.fullPath === node.fullPath)) {
-                        allResults.push(this._normalizeSearchResult(node, CHUB_AVATAR_BASE));
+                        allResults.push(this._normalizeSearchResult(node, getChubAvatarBase()));
                     }
                 }
             }
@@ -666,10 +666,10 @@ class ChubProvider extends ProviderBase {
                     search: name, first: '15', sort: 'download_count',
                     nsfw: 'true', nsfl: 'true', include_forks: 'true', min_tokens: '50'
                 });
-                const nameResp = await fetchWithProxy(`${CHUB_API_BASE}/search?${nameParams}`, { method: 'GET', headers });
+                const nameResp = await fetchWithProxy(`${getChubApiBase()}/search?${nameParams}`, { method: 'GET', headers });
                 if (nameResp.ok) {
                     const nameData = await nameResp.json();
-                    allResults = this._extractNodes(nameData).map(n => this._normalizeSearchResult(n, CHUB_AVATAR_BASE));
+                    allResults = this._extractNodes(nameData).map(n => this._normalizeSearchResult(n, getChubAvatarBase()));
                 }
             }
 
@@ -681,7 +681,7 @@ class ChubProvider extends ProviderBase {
     }
 
     getResultAvatarUrl(result) {
-        return result.avatarUrl || `${CHUB_AVATAR_BASE}${result.fullPath}/avatar`;
+        return result.avatarUrl || `${getChubAvatarBase()}${result.fullPath}/avatar`;
     }
 
     // ── Import Pipeline ─────────────────────────────────────
@@ -724,9 +724,9 @@ class ChubProvider extends ProviderBase {
             if (metadataMaxResUrl) imageUrls.push(metadataMaxResUrl);
             if (hitData?.avatar_url) imageUrls.push(hitData.avatar_url);
             if (metadataAvatarUrl) imageUrls.push(metadataAvatarUrl);
-            imageUrls.push(`${CHUB_AVATAR_BASE}${fullPath}/avatar.webp`);
-            imageUrls.push(`${CHUB_AVATAR_BASE}${fullPath}/avatar.png`);
-            imageUrls.push(`${CHUB_AVATAR_BASE}${fullPath}/chara_card_v2.png`);
+            imageUrls.push(`${getChubAvatarBase()}${fullPath}/avatar.webp`);
+            imageUrls.push(`${getChubAvatarBase()}${fullPath}/avatar.png`);
+            imageUrls.push(`${getChubAvatarBase()}${fullPath}/chara_card_v2.png`);
             const uniqueUrls = [...new Set(imageUrls)];
 
             let imageBuffer = null;
@@ -746,7 +746,7 @@ class ChubProvider extends ProviderBase {
                 characterName, hasGallery,
                 providerCharId: metadataId,
                 fullPath,
-                avatarUrl: `${CHUB_AVATAR_BASE}${fullPath}/avatar.webp`,
+                avatarUrl: `${getChubAvatarBase()}${fullPath}/avatar.webp`,
                 api
             });
         } catch (error) {
@@ -761,9 +761,9 @@ class ChubProvider extends ProviderBase {
 
     async fetchGalleryImages(linkInfo) {
         if (!linkInfo?.id) return [];
-        // Use module-level CHUB_GATEWAY_BASE from chub-api.js
+        // Resolved via getChubGatewayBase() from chub-api.js
         try {
-            const url = `${CHUB_GATEWAY_BASE}/api/gallery/project/${linkInfo.id}?limit=100&count=false`;
+            const url = `${getChubGatewayBase()}/api/gallery/project/${linkInfo.id}?limit=100&count=false`;
             const response = await fetchWithProxy(url, { headers: this._getHeaders() });
             const data = await response.json();
             if (!data.nodes || !Array.isArray(data.nodes)) return [];
@@ -857,7 +857,7 @@ class ChubProvider extends ProviderBase {
         if (!projectId) return null;
         try {
             const commitsResp = await fetchWithProxy(
-                `${CHUB_API_BASE}/api/v4/projects/${projectId}/repository/commits`,
+                `${getChubApiBase()}/api/v4/projects/${projectId}/repository/commits`,
                 { headers: this._getHeaders() }
             );
             const commits = await commitsResp.json();
@@ -865,7 +865,7 @@ class ChubProvider extends ProviderBase {
             if (!ref) return null;
 
             const cardResp = await fetchWithProxy(
-                `${CHUB_API_BASE}/api/v4/projects/${projectId}/repository/files/raw%252Fcard.json/raw?ref=${ref}`,
+                `${getChubApiBase()}/api/v4/projects/${projectId}/repository/files/raw%252Fcard.json/raw?ref=${ref}`,
                 { headers: this._getHeaders() }
             );
             return await cardResp.json() || null;

--- a/modules/providers/provider-utils.js
+++ b/modules/providers/provider-utils.js
@@ -35,8 +35,14 @@ export async function fetchWithProxy(url, opts = {}) {
             _proxyOrigins.add(origin);
         }
         if (directResponse) {
-            if (!directResponse.ok) throw new Error(`HTTP ${directResponse.status}`);
-            return directResponse;
+            if (directResponse.ok) return directResponse;
+            // Some upstreams reject the browser Origin even when CORS passes.
+            // Remember and retry through ST /proxy/ which strips Origin/Referer.
+            if (directResponse.status === 403 || directResponse.status === 401 || directResponse.status === 451) {
+                _proxyOrigins.add(origin);
+            } else {
+                throw new Error(`HTTP ${directResponse.status}`);
+            }
         }
     }
     const r = await fetch(`/proxy/${encodeURIComponent(url)}`, opts);

--- a/modules/providers/provider-utils.js
+++ b/modules/providers/provider-utils.js
@@ -38,7 +38,9 @@ export async function fetchWithProxy(url, opts = {}) {
             if (directResponse.ok) return directResponse;
             // Some upstreams reject the browser Origin even when CORS passes.
             // Remember and retry through ST /proxy/ which strips Origin/Referer.
-            if (directResponse.status === 403 || directResponse.status === 401 || directResponse.status === 451) {
+            // 401 is genuine auth-fail and should propagate; only origin-shaped
+            // rejections (403 forbidden, 451 region block) get retried.
+            if (directResponse.status === 403 || directResponse.status === 451) {
                 _proxyOrigins.add(origin);
             } else {
                 throw new Error(`HTTP ${directResponse.status}`);


### PR DESCRIPTION
## What

Adds a new online provider (CharaVault) and lets the existing ChubAI / CharacterTavern providers route through a self-hosted gateway when the user opts in.

Six commits, each self-contained:

1. **`provider-utils: fall back to /proxy/ on 401/403/451`** - widens `fetchWithProxy` to retry through ST `/proxy/` on origin-shaped rejections, not just network errors. Generic; useful for any provider hitting a hostile upstream. Later commit narrows this back to 403/451 only after testing showed 401 is genuine auth-fail and should propagate.
2. **`chub: route writes through fetchWithProxy, use CHUB_AVATAR_BASE`** - the chub provider already used `fetchWithProxy` for read paths but not for follow / unfollow / timeline / favorites / import. Behind a regional block those calls 401/403/451 and there is no retry. Routes every chub.ai fetch through `fetchWithProxy` so the new fallback applies uniformly. Drive-by: replace two inline `https://avatars.charhub.io/avatars/` strings with the existing `CHUB_AVATAR_BASE` constant they already paralleled.
3. **`Add CharaVault provider`** - new `modules/providers/charavault/` provider for [charavault.net](https://charavault.net). Supports browse + search (NSFW + lorebook filters), tag filtering, the visually-similar widget the site backs with image hashes, linked lorebooks, and full V2-card import. Endpoints default to `charavault.net` direct. Two optional settings (`charavaultGatewayUrl`, `charavaultGatewayKey`) let users proxy CharaVault. App-password is its own optional setting (`charavaultAppPassword`); the public anonymous tier works for read paths.
4. **`chub, chartavern: optional gateway base URL and key`** - ChubAI and CharacterTavern each split their service across multiple upstream hosts (`api.chub.ai` + `gateway.chub.ai` + `avatars.charhub.io`; `character-tavern.com/api` + the public site + `cards.character-tavern.com`). Replaces the module-load constants with runtime helpers that read from settings each call. Defaults still point at the real hosts; out-of-the-box behaviour is unchanged. For users who proxy through a self-hosted gateway, a single setting (`chubGatewayBaseUrl` / `chartavernGatewayBaseUrl`) is enough; helpers append the conventional path (`/v1/chub`, `/v1/ct`, etc.) for each host. Per-host overrides remain available for non-standard topologies. Settings UI exposes Base URL + Bearer Key by default with the per-host overrides tucked into an "Advanced" details element.
5. **`chartavern: send Authorization on gateway-routed fetch; restore CharaVault favicon`** - small follow-up after exercising the integration end-to-end: pass the gateway Bearer key as `Authorization` on chartavern's `ctFetch` / `fetchTopTags`, restore the `iconUrl` getter on the CharaVault provider (built from `getCvCdnBase()` so it follows the gateway override), and stop the `provider-utils` fallback from retrying on 401 (genuine auth-fail).
6. **`link reference proxy implementation in gateway settings hints`** - one-line addition to the three new "Gateway (optional)" sections pointing at [`AdamsGH/charlib-proxy`](https://github.com/AdamsGH/charlib-proxy), a small Node + Express passthrough that already exposes the path conventions baked into each provider's helper. Optional reading material for users who want to actually run a proxy.

## API quirks worth knowing (CharaVault)

Discovered while writing the provider; preserved as comments in the code:

- `/api/cards/similar` takes `path=` as the absolute server-side disk path stored in `entry.path`, **not** the `folder/file` form the public docs suggest. The `folder/file` form returns 404 for every card.
- The search-list entry carries `has_lorebook`; the per-card detail entry does not. The import path threads the search row through `buildCvCharacterCard` so the embedded extension metadata preserves the flag.

## Testing

Built and exercised the new provider end-to-end against both the direct upstreams and a self-hosted proxy (`charlib-proxy`):

- ChubAI search / import / favorites / follow - through both direct and gateway.
- CharacterTavern search / detail / import - through both direct and gateway.
- CharaVault browse / preview / find-similar / linked-lorebooks / import.
- CORS preflight + auth-bearer enforcement on the proxy side.

No changes to any other provider's behaviour.

## Settings added (defaults are all empty / `null`)

```
charavaultAppPassword
charavaultGatewayUrl
charavaultGatewayKey

chubGatewayBaseUrl
chubGatewayApiUrl       # advanced
chubGatewayGatewayUrl   # advanced
chubGatewayAvatarUrl    # advanced
chubGatewayKey

chartavernGatewayBaseUrl
chartavernGatewayApiUrl  # advanced
chartavernGatewaySiteUrl # advanced
chartavernGatewayCdnUrl  # advanced
chartavernGatewayKey
```
