### PR TITLE
Codex/nsfw toggle preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# legacy local experiment output
+/.superpowers/
+
+# local agent instructions
+AGENTS.md
+**/AGENTS.md

--- a/app/library.html
+++ b/app/library.html
@@ -1412,7 +1412,7 @@ https://jannyai.com/characters/uuid_slug
                                 <li>Set <strong>Collapse all browse preview sections by default</strong> in Settings → Character Details to start each preview with all sections collapsed except creator's notes (cleaner view for large cards)</li>
                                 <li>Some providers support login for additional features (favorites, following lists)</li>
                             </ul>
-                            <p class="info-tip"><i class="fa-solid fa-lightbulb"></i> Configure provider order and NSFW defaults in Settings → Online.</p>
+                            <p class="info-tip"><i class="fa-solid fa-lightbulb"></i> Configure provider order in Settings → Online. NSFW preference is remembered from each provider toggle.</p>
                         </div>
                         <div class="info-section">
                             <h4><i class="fa-solid fa-cat"></i> DataCat / JanitorAI</h4>

--- a/app/library.js
+++ b/app/library.js
@@ -467,9 +467,12 @@ const DEFAULT_SETTINGS = {
     civitaiApiKey: null,
 
     // ---- NSFW Toggles ----
+    chubNsfw: false,
+    jannyNsfw: false,
     pygmalionNsfw: false,
     wyvernNsfw: false,
     ctNsfw: false,
+    datacatNsfw: false,
 
     // ---- Search & Sort ----
     defaultSort: 'name_asc',

--- a/modules/providers/chartavern/chartavern-browse.js
+++ b/modules/providers/chartavern/chartavern-browse.js
@@ -53,7 +53,7 @@ let ctTotalPages = 1;
 let ctHasMore = true;
 let ctIsLoading = false;
 let ctCurrentSearch = '';
-let ctNsfwEnabled = true;
+let ctNsfwEnabled = false;
 let ctSortMode = 'most_popular';
 let ctSelectedChar = null;
 let ctGridRenderedCount = 0;
@@ -1457,11 +1457,8 @@ async function saveCookieAndConnect(cookieStr) {
         // Save cookie string to settings
         setSetting('ctCookie', cookieStr);
 
-        if (!ctNsfwEnabled) {
-            ctNsfwEnabled = true;
-            setSetting('ctNsfw', true);
-            updateNsfwToggle();
-        }
+        ctNsfwEnabled = getSetting('ctNsfw') === true;
+        updateNsfwToggle();
 
         if (validation.hasNsfw) {
             showToast('Connected to CharacterTavern — NSFW content available!', 'success');
@@ -1508,7 +1505,6 @@ async function tryCheckSession() {
             debugLog('[CTAuth] Session cookies expired or NSFW unavailable:', validation.reason);
             await ctLogout(apiRequest);
             ctNsfwEnabled = false;
-            setSetting('ctNsfw', false);
             setSetting('ctCookie', null);
             updateNsfwToggle();
             showToast('CharacterTavern session expired — please re-authenticate.', 'warning', 5000);
@@ -1517,8 +1513,7 @@ async function tryCheckSession() {
         }
 
         // Restore NSFW setting if session is still active
-        const savedNsfw = getSetting('ctNsfw');
-        if (savedNsfw) ctNsfwEnabled = true;
+        ctNsfwEnabled = getSetting('ctNsfw') === true;
         updateNsfwToggle();
     } else {
         // No active session in cl-helper - try to restore from saved cookie
@@ -1528,8 +1523,7 @@ async function tryCheckSession() {
             if (result.ok) {
                 const validation = await ctValidateSession(apiRequest);
                 if (validation.valid) {
-                    const savedNsfw = getSetting('ctNsfw');
-                    if (savedNsfw) ctNsfwEnabled = true;
+                    ctNsfwEnabled = getSetting('ctNsfw') === true;
                     updateNsfwToggle();
                     return;
                 }

--- a/modules/providers/chub/chub-browse.js
+++ b/modules/providers/chub/chub-browse.js
@@ -60,7 +60,7 @@ let chubHasMore = true;
 let chubIsLoading = false;
 let chubLoadToken = 0;
 let chubDiscoveryPreset = 'popular_week'; // Combined sort + time preset
-let chubNsfwEnabled = true; // Default to NSFW enabled
+let chubNsfwEnabled = false; // Default to SFW only
 let chubCurrentSearch = '';
 let chubSelectedChar = null;
 let chubToken = null; // URQL_TOKEN from chub.ai localStorage for Authorization Bearer
@@ -915,6 +915,8 @@ class ChubBrowseView extends BrowseView {
 
 
 function initChubView() {
+    chubNsfwEnabled = getSetting('chubNsfw') === true;
+
     // Sync dropdown values with JS state (browser may cache old form values)
     const discoveryPresetEl = document.getElementById('chubDiscoveryPreset');
     const timelineSortEl = document.getElementById('chubTimelineSortHeader');
@@ -1117,6 +1119,7 @@ function initChubView() {
     // NSFW toggle - single button toggle
     on('chubNsfwToggle', 'click', () => {
         chubNsfwEnabled = !chubNsfwEnabled;
+        setSetting('chubNsfw', chubNsfwEnabled);
         updateNsfwToggleState();
         
         // Refresh the appropriate view based on current mode
@@ -1232,7 +1235,7 @@ function initChubView() {
     // Load saved token on init
     loadChubToken();
     
-    // Initialize NSFW toggle state (defaults to enabled)
+    // Initialize NSFW toggle state from persisted preference
     updateNsfwToggleState();
     
     // Start fetching popular tags in the background
@@ -4164,4 +4167,3 @@ window.openChubCharPreview = openChubCharPreview;
 
 const chubBrowseView = new ChubBrowseView();
 export default chubBrowseView;
-

--- a/modules/providers/datacat/datacat-browse.js
+++ b/modules/providers/datacat/datacat-browse.js
@@ -100,7 +100,7 @@ let datacatFreshLimitWeek = 20;
 const FRESH_PAGE_INCREMENT = 20;
 
 // NSFW filter (client-side)
-let datacatNsfwEnabled = true;
+let datacatNsfwEnabled = false;
 
 // Faceted tag filtering
 let datacatActiveTagIds = new Set();
@@ -3294,6 +3294,8 @@ let delegatesInitialized = false;
 let modalEventsAttached = false;
 
 function initDatacatView() {
+    datacatNsfwEnabled = getSetting('datacatNsfw') === true;
+
     if (delegatesInitialized) return;
     delegatesInitialized = true;
 
@@ -3416,6 +3418,7 @@ function initDatacatView() {
     // NSFW toggle
     on('datacatNsfwToggle', 'click', () => {
         datacatNsfwEnabled = !datacatNsfwEnabled;
+        setSetting('datacatNsfw', datacatNsfwEnabled);
         updateNsfwToggle();
         if (datacatViewMode === 'following') {
             renderFollowing();

--- a/modules/providers/janny/janny-browse.js
+++ b/modules/providers/janny/janny-browse.js
@@ -34,6 +34,7 @@ const {
     cleanupCreatorNotesContainer,
     debounce,
     getProviderExcludeTags,
+    setSetting,
     renderLoadingState,
     renderSkeletonGrid,
     renderEmptyState,
@@ -55,7 +56,7 @@ let jannyHasMore = true;
 let jannyIsLoading = false;
 let jannyLoadToken = 0;
 let jannyCurrentSearch = '';
-let jannyNsfwEnabled = true;
+let jannyNsfwEnabled = false;
 let jannySortMode = 'newest';
 let jannySelectedChar = null;
 let jannyGridRenderedCount = 0;
@@ -939,6 +940,8 @@ let delegatesInitialized = false;
 let modalEventsAttached = false;
 
 function initJannyView() {
+    jannyNsfwEnabled = getSetting('jannyNsfw') === true;
+
     if (delegatesInitialized) return;
     delegatesInitialized = true;
 
@@ -1001,6 +1004,7 @@ function initJannyView() {
     // NSFW toggle
     on('jannyNsfwToggle', 'click', () => {
         jannyNsfwEnabled = !jannyNsfwEnabled;
+        setSetting('jannyNsfw', jannyNsfwEnabled);
         updateNsfwToggle();
         jannyCurrentPage = 1;
         loadCharacters(false);

--- a/modules/providers/pygmalion/pygmalion-browse.js
+++ b/modules/providers/pygmalion/pygmalion-browse.js
@@ -414,7 +414,6 @@ async function loadCharacters(append = false) {
                 setTimeout(() => loadCharacters(false), 0);
             } else {
                 pygNsfwEnabled = false;
-                setSetting('pygmalionNsfw', false);
                 updateNsfwToggle();
                 showToast('Pygmalion token expired — please re-authenticate.', 'warning', 5000);
                 openPygTokenModal();
@@ -1500,7 +1499,6 @@ function loadPygToken() {
 
     if (!pygToken && pygNsfwEnabled) {
         pygNsfwEnabled = false;
-        setSetting('pygmalionNsfw', false);
     }
     updateNsfwToggle();
     updateLoginUI();
@@ -1614,11 +1612,8 @@ async function loginWithCredentials(email, password) {
 
             scheduleTokenRefresh(token, email, password);
 
-            if (!pygNsfwEnabled) {
-                pygNsfwEnabled = true;
-                setSetting('pygmalionNsfw', true);
-                updateNsfwToggle();
-            }
+            pygNsfwEnabled = getSetting('pygmalionNsfw') === true;
+            updateNsfwToggle();
 
             showToast('Logged in to Pygmalion!', 'success');
             closePygTokenModal();
@@ -1784,11 +1779,10 @@ async function tryAutoLogin() {
                 savePygToken(token);
                 scheduleTokenRefresh(token, email, password);
 
-                if (!pygNsfwEnabled) {
+                if (!pygNsfwEnabled && getSetting('pygmalionNsfw') === true) {
                     pygNsfwEnabled = true;
-                    setSetting('pygmalionNsfw', true);
                     updateNsfwToggle();
-                    // Reload with NSFW if initial load was SFW-only
+                    // Reload with persisted NSFW preference if initial load was SFW-only
                     pygCurrentPage = 0;
                     loadCharacters(false);
                 }
@@ -2811,7 +2805,7 @@ class PygmalionBrowseView extends BrowseView {
         loadPygToken();
 
         // Restore persisted NSFW preference (only if token exists)
-        if (pygToken && getSetting('pygmalionNsfw')) {
+        if (pygToken && getSetting('pygmalionNsfw') === true) {
             pygNsfwEnabled = true;
         }
 

--- a/modules/providers/wyvern/wyvern-browse.js
+++ b/modules/providers/wyvern/wyvern-browse.js
@@ -1032,7 +1032,7 @@ function loadWyvernToken() {
         wyvernToken = savedToken;
         debugLog('[WyvernAuth] Loaded token from settings');
     }
-    wyvernNsfwEnabled = !!getSetting('wyvernNsfw');
+    wyvernNsfwEnabled = getSetting('wyvernNsfw') === true;
     updateWyvernNsfwToggle();
     updateWyvernLoginUI();
 }
@@ -1079,10 +1079,7 @@ async function wyvernLoginWithCredentials() {
 
         scheduleWyvernTokenRefresh(idToken, refreshToken);
 
-        if (!wyvernNsfwEnabled) {
-            wyvernNsfwEnabled = true;
-            setSetting('wyvernNsfw', true);
-        }
+        wyvernNsfwEnabled = getSetting('wyvernNsfw') === true;
         updateWyvernNsfwToggle();
         updateWyvernLoginUI();
 
@@ -1177,7 +1174,6 @@ function scheduleWyvernTokenRefresh(idToken, refreshToken) {
             if (!recovered) {
                 wyvernToken = null;
                 wyvernNsfwEnabled = false;
-                setSetting('wyvernNsfw', false);
                 updateWyvernNsfwToggle();
                 updateWyvernLoginUI();
             }


### PR DESCRIPTION
## Summary
- Default all online provider NSFW toggles to SFW-only on first load.
- Persist each provider's NSFW toggle through Character Library's existing settings helpers (`getSetting` / `setSetting`) instead of adding browser-only `localStorage`.
- Stop auth/login success flows from automatically enabling NSFW for Pygmalion, CharacterTavern, and Wyvern.
- Restore NSFW only when the user previously enabled it and the provider's auth/session requirements are satisfied.
- Update the Help copy to explain that NSFW preference is remembered from each provider toggle.

## Implementation Notes
- Adds explicit defaults for `chubNsfw`, `jannyNsfw`, and `datacatNsfw`, alongside the existing `pygmalionNsfw`, `wyvernNsfw`, and `ctNsfw` settings.
- Uses the existing SillyTavern extension settings persistence path via CL settings helpers, so no new backend API, storage file, provider contract, or migration is introduced.
- Keeps the toggle behavior provider-local and does not add a visible Settings UI option.

## Test Plan
- Ran `node --check` on the modified app/provider JS files.
- Ran `git diff --check`.
- Verified no new NSFW-specific `localStorage` usage was added.
- Verified no auth success path still forces NSFW on by writing `*Nsfw = true`.

***

This pull request updates the handling of NSFW (Not Safe For Work) content toggles across multiple online character providers. The main change is that each provider now remembers the user's NSFW preference individually, rather than relying on a single global or default setting. This results in a more consistent and user-friendly experience, especially when browsing or logging in to different providers. Additionally, the default state for NSFW toggles is now set to off (SFW) for all providers, and the UI/help text has been updated to reflect this new behavior.

**NSFW Toggle Persistence and Initialization**

* Each provider (`chub`, `janny`, `datacat`, `pygmalion`, `wyvern`, `chartavern`) now saves and restores its own NSFW toggle state using a dedicated setting (e.g., `chubNsfw`, `jannyNsfw`), ensuring the user's preference is remembered per provider. [[1]](diffhunk://#diff-bc2207920093b08c4f45f96711d2f603444e7de0b6ae601082b6f4f0c9d0911fR470-R475) [[2]](diffhunk://#diff-1a941bca1cf2a4470bf261975e1a07808e3c66564a45df696e48eb2dac6fd78dR918-R919) [[3]](diffhunk://#diff-e4e6b91fd53f1267c653a7b1b1aae94762589c40a807a75c509b3f25cb70620cR3297-R3298) [[4]](diffhunk://#diff-9f1524c3abda59aa6e78ede6ec8179894fb55a77b08240bab14d0067cad80227R943-R944) [[5]](diffhunk://#diff-e2a0b4037f42db54a73e7608192e1503d1289f1aff752797dbb24dea7ecad889L1460-L1464) [[6]](diffhunk://#diff-cd7ce9c68d6d49734eaff020cc21c8c7740ec479b3eebd985caf504413305eadL1617-L1621) [[7]](diffhunk://#diff-781c9a554258834153096a14b3ee7243106acf0cc15f14c91a490bb988f4154fL1035-R1035)

* The default value for all provider NSFW toggles is now `false` (SFW), instead of previously being `true` (NSFW). [[1]](diffhunk://#diff-1a941bca1cf2a4470bf261975e1a07808e3c66564a45df696e48eb2dac6fd78dL63-R63) [[2]](diffhunk://#diff-9f1524c3abda59aa6e78ede6ec8179894fb55a77b08240bab14d0067cad80227L58-R59) [[3]](diffhunk://#diff-e4e6b91fd53f1267c653a7b1b1aae94762589c40a807a75c509b3f25cb70620cL103-R103) [[4]](diffhunk://#diff-e2a0b4037f42db54a73e7608192e1503d1289f1aff752797dbb24dea7ecad889L56-R56)

**UI and User Guidance**

* The help text in the library UI has been updated to clarify that provider order is configured in settings, and that NSFW preference is remembered per provider toggle, rather than set globally.

**Provider-Specific Logic Updates**

* All NSFW toggle event handlers now persist the new state to settings whenever toggled, ensuring changes are saved immediately. [[1]](diffhunk://#diff-1a941bca1cf2a4470bf261975e1a07808e3c66564a45df696e48eb2dac6fd78dR1122) [[2]](diffhunk://#diff-e4e6b91fd53f1267c653a7b1b1aae94762589c40a807a75c509b3f25cb70620cR3421) [[3]](diffhunk://#diff-9f1524c3abda59aa6e78ede6ec8179894fb55a77b08240bab14d0067cad80227R1007)

* On login and session restoration, providers now restore the NSFW setting from the persisted value, rather than always enabling or disabling it by default. [[1]](diffhunk://#diff-e2a0b4037f42db54a73e7608192e1503d1289f1aff752797dbb24dea7ecad889L1520-R1516) [[2]](diffhunk://#diff-e2a0b4037f42db54a73e7608192e1503d1289f1aff752797dbb24dea7ecad889L1531-R1526) [[3]](diffhunk://#diff-cd7ce9c68d6d49734eaff020cc21c8c7740ec479b3eebd985caf504413305eadL2814-R2808) [[4]](diffhunk://#diff-781c9a554258834153096a14b3ee7243106acf0cc15f14c91a490bb988f4154fL1082-R1082)

**Codebase Consistency and Cleanup**

* Redundant or unnecessary calls to persist NSFW settings (especially forced disables) have been removed, and all NSFW state transitions are now consistently handled via the per-provider setting. [[1]](diffhunk://#diff-cd7ce9c68d6d49734eaff020cc21c8c7740ec479b3eebd985caf504413305eadL417) [[2]](diffhunk://#diff-cd7ce9c68d6d49734eaff020cc21c8c7740ec479b3eebd985caf504413305eadL1503) [[3]](diffhunk://#diff-cd7ce9c68d6d49734eaff020cc21c8c7740ec479b3eebd985caf504413305eadL1787-R1785) [[4]](diffhunk://#diff-781c9a554258834153096a14b3ee7243106acf0cc15f14c91a490bb988f4154fL1180)

These changes ensure that NSFW preferences are user-friendly, predictable, and consistent across all supported providers.