### PR TITLE
Fix menus falling behind the card grid on ios devices

### DIFF
--- a/app/library.css
+++ b/app/library.css
@@ -4737,6 +4737,11 @@ input[type="search"]::-webkit-search-results-decoration {
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
+    /* iOS Safari paints composited layers (the card grid animates transforms and
+       uses backdrop-filter) above non-composited siblings regardless of z-index,
+       which left these menus stuck behind the cards. Promote the menu to its own
+       compositing layer so its z-index is honored. translateZ(0) is visually inert. */
+    transform: translateZ(0);
 }
 
 .dropdown-menu.hidden {


### PR DESCRIPTION
# Rationale

On iOS Safari, composited layers paint above non-composited layers regardless of z-index. The character card grid is composited (it animates transform and uses backdrop-filter), so several .dropdown-menu popups with the absolute z-index: 1000 end up stuck behind the cards. This makes these menus unusable on iPads and iOS devices.

Tried to keep this fix super concise and minimal, just to fix this one minor usability bug.

## Changes
- Added transform: translateZ(0) to the base .dropdown-menu rule in app/library.css, promoting it to its own compositing layer so its existing z-index is honored above the cards.

This single rule fixes all of the affected menus (More/ellipsis, Playlists, Search in, and the Online-tab Tags & Features dropdowns) since they share the base class. Should have no impact at all on the desktop rendering.