### PR TITLE
Add native Saucepan extraction to bypass DataCat retrieval limits

### DIFF
--- a/app/library.html
+++ b/app/library.html
@@ -2619,6 +2619,47 @@ https://jannyai.com/characters/uuid_slug
                                     </div>
                                 </div>
                                 <div class="settings-group">
+                                    <div class="settings-group-title"><i class="fa-solid fa-bowl-food"></i> Saucepan Account</div>
+                                    <div class="settings-row">
+                                        <span class="settings-hint">Optional. A Saucepan login (or a pasted Bearer token) enables native extraction of open-definition Saucepan characters, without waiting on DataCat's extraction service.</span>
+                                    </div>
+                                    <div class="settings-row">
+                                        <label>Handle:</label>
+                                        <div class="settings-input-group">
+                                            <input type="text" id="settingsSaucepanHandle" class="glass-input" placeholder="Saucepan handle" autocomplete="off">
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <label>Password:</label>
+                                        <div class="settings-input-group">
+                                            <input type="password" id="settingsSaucepanPassword" class="glass-input" placeholder="Password (not stored)" autocomplete="off" data-sensitive="true">
+                                            <button id="saucepanLoginBtn" class="settings-verify-btn" title="Log in and store the session token">
+                                                <i class="fa-solid fa-right-to-bracket"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="settings-row">
+                                        <label>Token:</label>
+                                        <div class="settings-input-group">
+                                            <input type="password" id="settingsSaucepanToken" placeholder="No token" autocomplete="off" data-sensitive="true">
+                                            <button id="toggleSaucepanTokenVisibility" class="glass-btn icon-only" title="Show/Hide">
+                                                <i class="fa-solid fa-eye"></i>
+                                            </button>
+                                            <button id="saveSaucepanTokenBtn" class="settings-verify-btn" title="Save pasted token">
+                                                <i class="fa-solid fa-floppy-disk"></i>
+                                            </button>
+                                            <button id="validateSaucepanBtn" class="settings-verify-btn" title="Test token">
+                                                <i class="fa-solid fa-check"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="settings-row" style="gap: 8px;">
+                                        <button id="saucepanClearTokenBtn" class="settings-action-btn danger">
+                                            <i class="fa-solid fa-trash-can"></i> Clear Token
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="settings-group">
                                     <div class="settings-group-title"><i class="fa-solid fa-cloud-arrow-down"></i> Extraction</div>
                                     <div class="settings-row">
                                         <label class="settings-checkbox-label">

--- a/app/library.js
+++ b/app/library.js
@@ -490,6 +490,7 @@ const DEFAULT_SETTINGS = {
     wyvernUid: null,
     wyvernRememberCredentials: true,
     datacatToken: null,
+    saucepanToken: null,
     datacatPublicFeed: false,
     datacatReextractOnUpdate: false,
     datacatFlareSolverrUrl: '',
@@ -1593,6 +1594,10 @@ function setupSettingsModal() {
     const toggleWyvernPasswordVisibility = document.getElementById('toggleWyvernPasswordVisibility');
     const datacatTokenInput = document.getElementById('settingsDatacatToken');
     const toggleDatacatTokenVisibility = document.getElementById('toggleDatacatTokenVisibility');
+    const saucepanHandleInput = document.getElementById('settingsSaucepanHandle');
+    const saucepanPasswordInput = document.getElementById('settingsSaucepanPassword');
+    const saucepanTokenInput = document.getElementById('settingsSaucepanToken');
+    const toggleSaucepanTokenVisibility = document.getElementById('toggleSaucepanTokenVisibility');
     const datacatPluginBanner = document.getElementById('datacatPluginBanner');
     const datacatSettingsFields = document.getElementById('datacatSettingsFields');
     const datacatSessionStatus = document.getElementById('datacatSessionStatus');
@@ -2139,6 +2144,7 @@ function setupSettingsModal() {
         if (wyvernPasswordInput) wyvernPasswordInput.value = getSetting('wyvernPassword') || '';
         if (wyvernRememberCredsCheckbox) wyvernRememberCredsCheckbox.checked = getSetting('wyvernRememberCredentials') || false;
         if (datacatTokenInput) datacatTokenInput.value = getSetting('datacatToken') || '';
+        if (saucepanTokenInput) saucepanTokenInput.value = getSetting('saucepanToken') || '';
         const civitaiApiKeyInput = document.getElementById('settingsCivitaiApiKey');
         if (civitaiApiKeyInput) civitaiApiKeyInput.value = getSetting('civitaiApiKey') || '';
         const datacatPublicFeedCheckbox = document.getElementById('datacatPublicFeedCheckbox');
@@ -3778,6 +3784,126 @@ function setupSettingsModal() {
                 if (datacatTokenInput) datacatTokenInput.value = '';
                 showToast('DataCat session cleared', 'info');
                 updateDatacatSessionStatus();
+            } catch (err) {
+                showToast(`Clear error: ${err.message}`, 'error');
+            }
+        };
+    }
+
+    // ---- Saucepan Account (native extraction) ----
+    // Token persistence lives in window.saucepanLogin/saucepanSetToken/
+    // saucepanClearSession (datacat-provider.js); handlers here only drive the UI.
+    if (toggleSaucepanTokenVisibility && saucepanTokenInput) {
+        toggleSaucepanTokenVisibility.onclick = () => {
+            const isPassword = saucepanTokenInput.type === 'password';
+            saucepanTokenInput.type = isPassword ? 'text' : 'password';
+            toggleSaucepanTokenVisibility.innerHTML = `<i class="fa-solid fa-eye${isPassword ? '-slash' : ''}"></i>`;
+        };
+    }
+
+    const saucepanLoginBtn = document.getElementById('saucepanLoginBtn');
+    if (saucepanLoginBtn) {
+        saucepanLoginBtn.onclick = async () => {
+            const handle = (saucepanHandleInput?.value || '').trim();
+            const password = saucepanPasswordInput?.value || '';
+            if (!handle || !password) {
+                showToast('Enter your Saucepan handle and password', 'warning');
+                return;
+            }
+            if (!window.saucepanLogin) {
+                showToast('DataCat module not ready', 'error');
+                return;
+            }
+            const originalHtml = saucepanLoginBtn.innerHTML;
+            saucepanLoginBtn.disabled = true;
+            saucepanLoginBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
+            try {
+                const result = await window.saucepanLogin(handle, password);
+                if (result?.ok && result.token) {
+                    if (saucepanTokenInput) saucepanTokenInput.value = result.token;
+                    if (saucepanPasswordInput) saucepanPasswordInput.value = '';
+                    showToast('Saucepan login successful', 'success');
+                } else {
+                    showToast(`Saucepan login failed: ${result?.error || 'unknown error'}`, 'error');
+                }
+            } catch (err) {
+                showToast(`Saucepan login error: ${err.message}`, 'error');
+            } finally {
+                saucepanLoginBtn.disabled = false;
+                saucepanLoginBtn.innerHTML = originalHtml;
+            }
+        };
+    }
+
+    const saveSaucepanTokenBtn = document.getElementById('saveSaucepanTokenBtn');
+    if (saveSaucepanTokenBtn) {
+        saveSaucepanTokenBtn.onclick = async () => {
+            const pasted = (saucepanTokenInput?.value || '').trim();
+            if (!pasted) {
+                showToast('Paste a Saucepan token first', 'warning');
+                return;
+            }
+            if (!window.saucepanSetToken) {
+                showToast('DataCat module not ready', 'error');
+                return;
+            }
+            try {
+                const result = await window.saucepanSetToken(pasted);
+                if (result?.ok) {
+                    showToast('Saucepan token saved', 'success');
+                } else {
+                    showToast(result?.error || 'Failed to save token', 'warning');
+                }
+            } catch (err) {
+                showToast(`Save error: ${err.message}`, 'error');
+            }
+        };
+    }
+
+    const validateSaucepanBtn = document.getElementById('validateSaucepanBtn');
+    if (validateSaucepanBtn) {
+        validateSaucepanBtn.onclick = async () => {
+            if (!window.saucepanValidateSession) {
+                showToast('DataCat module not ready', 'error');
+                return;
+            }
+            const originalHtml = validateSaucepanBtn.innerHTML;
+            validateSaucepanBtn.classList.remove('success', 'error');
+            validateSaucepanBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
+            validateSaucepanBtn.disabled = true;
+            try {
+                const result = await window.saucepanValidateSession();
+                if (result?.valid) {
+                    validateSaucepanBtn.classList.add('success');
+                    validateSaucepanBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
+                    showToast('Saucepan token is valid', 'success');
+                } else {
+                    validateSaucepanBtn.classList.add('error');
+                    validateSaucepanBtn.innerHTML = '<i class="fa-solid fa-times"></i>';
+                    showToast(`Saucepan token invalid: ${result?.reason || 'unknown'}`, 'error');
+                }
+            } catch (err) {
+                validateSaucepanBtn.classList.add('error');
+                validateSaucepanBtn.innerHTML = '<i class="fa-solid fa-exclamation"></i>';
+                showToast(`Validation error: ${err.message}`, 'error');
+            } finally {
+                validateSaucepanBtn.disabled = false;
+                setTimeout(() => {
+                    validateSaucepanBtn.classList.remove('success', 'error');
+                    validateSaucepanBtn.innerHTML = originalHtml;
+                }, 3000);
+            }
+        };
+    }
+
+    const saucepanClearTokenBtn = document.getElementById('saucepanClearTokenBtn');
+    if (saucepanClearTokenBtn) {
+        saucepanClearTokenBtn.onclick = async () => {
+            try {
+                if (window.saucepanClearSession) await window.saucepanClearSession();
+                else setSetting('saucepanToken', null);
+                if (saucepanTokenInput) saucepanTokenInput.value = '';
+                showToast('Saucepan token cleared', 'info');
             } catch (err) {
                 showToast(`Clear error: ${err.message}`, 'error');
             }

--- a/extras/cl-helper/index.js
+++ b/extras/cl-helper/index.js
@@ -1455,6 +1455,8 @@ const SAUCEPAN_ALLOWED_PATHS = [
     /^\/api\/v1\/search$/,
     /^\/api\/v1\/companions-of-user$/,
     /^\/api\/v1\/companion$/,
+    /^\/api\/v1\/companion\/definition$/,
+    /^\/cdn\/.+$/,
 ];
 const SAUCEPAN_POST_PATH = '/api/v1/search';
 const SAUCEPAN_MAX_SEARCH_LEN = 500;
@@ -1462,6 +1464,63 @@ const SAUCEPAN_MAX_TAG_LEN = 64;
 const SAUCEPAN_MAX_TAGS = 100;
 const SAUCEPAN_MAX_DATE_LEN = 30;
 const SAUCEPAN_MAX_ORDER_LEN = 32;
+
+let saucepanToken = null;
+
+function saucepanHeaders(token) {
+    const headers = {
+        'User-Agent': SAUCEPAN_UA,
+        Accept: '*/*',
+        'Accept-Encoding': 'gzip, deflate, br',
+        Origin: SAUCEPAN_ORIGIN,
+        Referer: SAUCEPAN_ORIGIN + '/',
+        'x-saucepan-client-version': '1',
+    };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    return headers;
+}
+
+// The search endpoint is anonymous, so it cannot prove a token is valid.
+// The definition endpoint requires auth: grab any open-definition companion
+// id via search, then request its definition with the token under test.
+async function testSaucepanToken(token) {
+    // The search endpoint 422s unless every field is present.
+    const searchResp = await fetch(`${SAUCEPAN_BASE}/api/v1/search`, {
+        method: 'POST',
+        headers: { ...saucepanHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            text_search: null,
+            tags: [],
+            excluded_tags: [],
+            fandom_tags: [],
+            excluded_fandom_tags: [],
+            match_all_fandom_tags: false,
+            match_all_tags: true,
+            limit: 1,
+            offset: 0,
+            sus: true,
+            extra_spicy: null,
+            order_by: 'created',
+            asc: false,
+            posted_at_from: null,
+            posted_at_to: null,
+            hide_hidden_content: false,
+            open_definition_only: true,
+        }),
+    });
+    if (!searchResp.ok) throw new Error(`Saucepan search HTTP ${searchResp.status} while validating token`);
+    const searchData = JSON.parse(await readSaucepanBody(searchResp));
+    const companionId = searchData?.companions?.[0]?.id;
+    if (!companionId) throw new Error('No companion available to validate token against');
+
+    return fetch(`${SAUCEPAN_BASE}/api/v1/companion/definition?companion_id=${encodeURIComponent(companionId)}`, {
+        method: 'GET',
+        headers: {
+            ...saucepanHeaders(token),
+            Referer: `${SAUCEPAN_ORIGIN}/companion/${companionId}`,
+        },
+    });
+}
 
 function sanitizeSaucepanSearchBody(input) {
     if (!input || typeof input !== 'object') return null;
@@ -1527,7 +1586,242 @@ async function readSaucepanBody(response) {
     return text;
 }
 
+// Saucepan ships companion definitions as a shuffled fragment list padded
+// with decoy fragments, to frustrate naive scrapers (a plain text-join yields
+// garbled prose). Each real fragment carries a `proof` hash; decoys don't
+// validate. Reassembly (ported verbatim from Saucepan's own web bundle):
+//   1. keep only fragments whose proof matches hash(mask, key^mask, text)
+//   2. order the survivors by (key ^ mask) ascending
+//   3. concatenate their text
+// The hash is FNV-1a over the UTF-8 text, seeded from the mask and derived key.
+const SAUCEPAN_FNV_OFFSET = 2166136261;
+const SAUCEPAN_FNV_PRIME = 16777619;
+
+function saucepanRotl(value, bits) {
+    return ((value << bits) | (value >>> (32 - bits))) >>> 0;
+}
+
+function saucepanFragmentHash(mask, derivedKey, text) {
+    const bytes = new TextEncoder().encode(text);
+    let h = (SAUCEPAN_FNV_OFFSET ^ saucepanRotl(mask, 7) ^ saucepanRotl(derivedKey, 13)) >>> 0;
+    for (const b of bytes) {
+        h ^= b;
+        h = Math.imul(h, SAUCEPAN_FNV_PRIME) >>> 0;
+    }
+    return h >>> 0;
+}
+
+function assembleSaucepanFragments(content) {
+    const fragments = Array.isArray(content?.fragments) ? content.fragments : [];
+    const mask = (content?.mask ?? 0) >>> 0;
+    return fragments
+        .filter(f => {
+            if (!f || typeof f.text !== 'string') return false;
+            const derivedKey = (f.key ^ mask) >>> 0;
+            return saucepanFragmentHash(mask, derivedKey, f.text) === (f.proof >>> 0);
+        })
+        .sort((a, b) => ((a.key ^ mask) >>> 0) - ((b.key ^ mask) >>> 0))
+        .map(f => f.text)
+        .join('');
+}
+
+// GET a Saucepan JSON endpoint with auth, decoding the (possibly zstd) body.
+// Returns { ok, status, data } with data === null on non-JSON responses.
+async function fetchSaucepanJson(path, token, companionId) {
+    const response = await fetch(`${SAUCEPAN_BASE}${path}`, {
+        method: 'GET',
+        headers: {
+            ...saucepanHeaders(token),
+            Referer: `${SAUCEPAN_ORIGIN}/companion/${companionId}`,
+        },
+    });
+    const text = await readSaucepanBody(response);
+    let data = null;
+    try { data = JSON.parse(text); } catch { /* leave null */ }
+    return { ok: response.ok, status: response.status, data };
+}
+
 function registerSaucepanRoutes(router) {
+    // Saucepan auth: password login
+    router.post('/saucepan-login', async (req, res) => {
+        const { handle, password } = req.body ?? {};
+        if (!handle || typeof handle !== 'string' || !password || typeof password !== 'string') {
+            return res.status(400).json({ error: 'handle and password are required' });
+        }
+        if (handle.length > 64 || password.length > 128) {
+            return res.status(400).json({ error: 'handle or password too long' });
+        }
+
+        try {
+            const response = await fetch(`${SAUCEPAN_BASE}/api/v1/auth/sign_in_password`, {
+                method: 'POST',
+                headers: {
+                    ...saucepanHeaders(),
+                    'Content-Type': 'application/json',
+                    Referer: `${SAUCEPAN_ORIGIN}/sign-in`,
+                },
+                body: JSON.stringify({ handle: handle.trim(), password }),
+            });
+
+            let data = {};
+            try {
+                data = JSON.parse(await readSaucepanBody(response));
+            } catch { /* non-JSON error body */ }
+            if (!response.ok) {
+                const msg = data?.error?.message || `HTTP ${response.status}`;
+                return res.status(response.status).json({ ok: false, error: msg });
+            }
+
+            const token = data?.token || data?.access_token || data?.session_token || data?.sessionToken;
+            if (!token) {
+                return res.status(502).json({ ok: false, error: 'Login succeeded but no token was returned' });
+            }
+
+            saucepanToken = token;
+            console.log('[cl-helper] Saucepan login succeeded');
+            res.json({ ok: true, token });
+        } catch (err) {
+            console.error('[cl-helper] Saucepan login error:', err.message);
+            res.status(502).json({ ok: false, error: err.message });
+        }
+    });
+
+    // Store a user-provided Saucepan token
+    router.post('/saucepan-set-token', async (req, res) => {
+        const { token } = req.body ?? {};
+        if (!token || typeof token !== 'string' || !token.trim()) {
+            return res.status(400).json({ error: 'token string is required' });
+        }
+        if (token.length > 2048) {
+            return res.status(400).json({ error: 'Token too long' });
+        }
+        saucepanToken = token.trim();
+        console.log('[cl-helper] Saucepan token stored');
+        res.json({ ok: true });
+    });
+
+    // Clear stored Saucepan token
+    router.post('/saucepan-clear-token', (_req, res) => {
+        saucepanToken = null;
+        console.log('[cl-helper] Saucepan token cleared');
+        res.json({ ok: true });
+    });
+
+    // Validate stored Saucepan token
+    router.get('/saucepan-validate', async (_req, res) => {
+        if (!saucepanToken) {
+            return res.json({ valid: false, reason: 'no token stored' });
+        }
+        try {
+            const response = await testSaucepanToken(saucepanToken);
+            if (response.ok) {
+                res.json({ valid: true });
+            } else {
+                const text = await readSaucepanBody(response).catch(() => '');
+                console.warn(`[cl-helper] Saucepan validate failed: HTTP ${response.status}`);
+                res.json({ valid: false, reason: `HTTP ${response.status}: ${text.slice(0, 200)}` });
+            }
+        } catch (err) {
+            console.error('[cl-helper] Saucepan validate error:', err.message);
+            res.json({ valid: false, reason: err.message });
+        }
+    });
+
+    // Native Saucepan extraction: reassemble the companion's obfuscated
+    // fragments into a usable card. Pulls two endpoints:
+    //   /api/v1/companion/definition -> named prose sections (body, example
+    //     dialogue, advanced prompt, response formatting)
+    //   /api/v2/companions/{id}      -> starting scenarios (the greetings that
+    //     become first_mes / alternate_greetings; absent from the definition)
+    router.post('/saucepan-extract', async (req, res) => {
+        const bodyToken = typeof req.body?.token === 'string' && req.body.token.length <= 2048
+            ? req.body.token.trim()
+            : null;
+        const token = bodyToken || saucepanToken;
+        if (!token) {
+            return res.status(401).json({ error: 'No Saucepan token configured' });
+        }
+
+        const { url } = req.body ?? {};
+        if (!url || typeof url !== 'string') {
+            return res.status(400).json({ error: 'url string is required' });
+        }
+        if (url.length > 512) {
+            return res.status(400).json({ error: 'URL too long' });
+        }
+
+        let companionId;
+        try {
+            const parsed = new URL(url);
+            if (!/^(www\.)?saucepan\.ai$/i.test(parsed.hostname)) {
+                return res.status(400).json({ error: 'Only Saucepan companion URLs are supported' });
+            }
+            const m = parsed.pathname.match(/^\/companion\/([a-f0-9-]{8,64})\/?$/i);
+            if (!m) {
+                return res.status(400).json({ error: 'Invalid companion URL path' });
+            }
+            companionId = m[1];
+        } catch {
+            return res.status(400).json({ error: 'Invalid URL' });
+        }
+
+        try {
+            const [defRes, compRes] = await Promise.all([
+                fetchSaucepanJson(`/api/v1/companion/definition?companion_id=${encodeURIComponent(companionId)}`, token, companionId),
+                fetchSaucepanJson(`/api/v2/companions/${encodeURIComponent(companionId)}`, token, companionId),
+            ]);
+
+            // The definition endpoint is authoritative; surface its auth errors.
+            if (!defRes.ok) {
+                const msg = defRes.data?.error?.message || `Saucepan HTTP ${defRes.status}`;
+                return res.status(defRes.status).json({ error: msg });
+            }
+            if (!defRes.data) {
+                return res.status(502).json({ error: 'Invalid JSON from Saucepan' });
+            }
+
+            // Reassemble each definition section's shuffled fragments back into
+            // prose, dropping the decoy fragments Saucepan injects (see
+            // assembleSaucepanFragments).
+            const sections = Array.isArray(defRes.data.sections) ? defRes.data.sections : [];
+            const assembled = {};
+            for (const section of sections) {
+                const title = section?.title;
+                const content = section?.content;
+                if (!title || !content) continue;
+                assembled[title] = assembleSaucepanFragments(content);
+            }
+
+            const companion = compRes.data?.companion || null;
+            if (!compRes.ok || !companion) {
+                console.warn(`[cl-helper] Saucepan extract: greetings unavailable (companions/${companionId} HTTP ${compRes.status})`);
+            }
+
+            // Greetings live only on the v2 companion object as starting
+            // scenarios; each scenario message is fragment-obfuscated too.
+            const greetings = [];
+            const scenarios = Array.isArray(companion?.starting_scenarios_fragments)
+                ? companion.starting_scenarios_fragments
+                : [];
+            for (const scenario of scenarios) {
+                const text = assembleSaucepanFragments(scenario?.message);
+                if (text && text.trim()) {
+                    greetings.push({ title: typeof scenario?.title === 'string' ? scenario.title : '', text });
+                }
+            }
+
+            // Fall back to the v2 body if the definition lacked Companion Core.
+            if (!assembled['Companion Core'] && companion?.full_description_fragments) {
+                assembled['Companion Core'] = assembleSaucepanFragments(companion.full_description_fragments);
+            }
+
+            res.json({ success: true, companionId, assembled, greetings });
+        } catch (err) {
+            console.error('[cl-helper] Saucepan extract error:', err.message);
+            res.status(502).json({ error: `Failed to reach Saucepan: ${err.message}` });
+        }
+    });
+
     const handleProxy = async (req, res) => {
         const targetPath = '/' + req.params[0];
         const normalizedPath = new URL(targetPath, SAUCEPAN_BASE).pathname;
@@ -1542,6 +1836,7 @@ function registerSaucepanRoutes(router) {
             return res.status(403).json({ error: `Proxy target must be ${SAUCEPAN_HOSTNAME}` });
         }
 
+        const isCdn = normalizedPath.startsWith('/cdn/');
         const isPost = req.method === 'POST';
         let bodyStr = null;
         if (isPost) {
@@ -1557,15 +1852,17 @@ function registerSaucepanRoutes(router) {
 
         const headers = {
             'User-Agent': SAUCEPAN_UA,
-            'Accept': '*/*',
+            'Accept': isCdn ? 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8' : '*/*',
             // Deliberately omits zstd: undici auto-decompresses gzip/deflate/br,
             // and Saucepan should respect the negotiated encoding. The zstd
             // fallback in readSaucepanBody covers servers that ignore us.
             'Accept-Encoding': 'gzip, deflate, br',
             'Origin': SAUCEPAN_ORIGIN,
             'Referer': SAUCEPAN_ORIGIN + '/',
+            'x-saucepan-client-version': '1',
         };
         if (isPost) headers['Content-Type'] = 'application/json';
+        if (saucepanToken && !isCdn) headers['Authorization'] = `Bearer ${saucepanToken}`;
 
         try {
             const response = await fetch(targetUrl.toString(), {
@@ -1574,6 +1871,26 @@ function registerSaucepanRoutes(router) {
                 body: bodyStr ?? undefined,
                 redirect: 'follow',
             });
+
+            // CDN images: return binary bytes straight back; do not run through
+            // the zstd/text reader used for API responses.
+            if (isCdn) {
+                const contentLength = parseInt(response.headers.get('content-length'), 10);
+                if (contentLength > SAUCEPAN_MAX_BYTES) {
+                    return res.status(413).json({ error: 'Saucepan image too large' });
+                }
+                const buf = Buffer.from(await response.arrayBuffer());
+                if (buf.length > SAUCEPAN_MAX_BYTES) {
+                    return res.status(413).json({ error: 'Saucepan image too large' });
+                }
+                res.status(response.status);
+                res.set('Content-Type', response.headers.get('content-type') || 'image/jpeg');
+                // Saucepan serves images immutable; keeping its cache headers
+                // stops the browser re-requesting every avatar through us.
+                const cacheControl = response.headers.get('cache-control');
+                if (cacheControl) res.set('Cache-Control', cacheControl);
+                return res.send(buf);
+            }
 
             const text = await readSaucepanBody(response);
             res.status(response.status);

--- a/modules/providers/datacat/datacat-api.js
+++ b/modules/providers/datacat/datacat-api.js
@@ -4,6 +4,7 @@
 
 import { CL_HELPER_PLUGIN_BASE, slugify, stripHtml, fetchWithProxy } from '../provider-utils.js';
 import { getSearchToken, JANNY_SEARCH_URL, JANNY_SITE_BASE, TAG_MAP as JANNY_TAG_MAP } from '../janny/janny-api.js';
+import { resolveSaucepanImageUrl, SAUCEPAN_CDN_PROXY_BASE } from './saucepan-api.js';
 
 export { slugify, stripHtml, JANNY_TAG_MAP };
 
@@ -35,7 +36,7 @@ export const DATACAT_API_BASE = 'https://datacat.run';
 
 // DataCat aggregates from multiple sources. Each has its own avatar URL convention:
 //   - JanitorAI: bare filename, served from ella.janitorai.com
-//   - Saucepan: full https URL (cdn.saucepan.ai/...) embedded in the avatar field
+//   - Saucepan: full https URL (saucepan.ai/cdn/...) embedded in the avatar field
 // Future sources should be added here. Use resolveDatacatAvatarUrl() to get a usable URL.
 export const DATACAT_JANITOR_IMAGE_BASE = 'https://ella.janitorai.com/bot-avatars/';
 
@@ -44,11 +45,14 @@ export const DATACAT_JANITOR_IMAGE_BASE = 'https://ella.janitorai.com/bot-avatar
  * Saucepan and other future sources embed full URLs in the avatar field;
  * JanitorAI uses bare filenames that need the ella.janitorai.com prefix.
  * @param {Object} hit - DataCat character object (listing or detail)
- * @returns {string|null} Full URL or null if no avatar
+ * @returns {string|null} Full URL (or local proxy path) or null if no avatar
  */
 export function resolveDatacatAvatarUrl(hit) {
     const avatar = hit?.avatar;
     if (!avatar || typeof avatar !== 'string') return null;
+    const proxied = resolveSaucepanImageUrl(avatar);
+    // Covers freshly rewritten URLs and already-proxied paths alike.
+    if (proxied.startsWith(SAUCEPAN_CDN_PROXY_BASE)) return proxied;
     const url = /^https?:\/\//i.test(avatar) ? avatar : `${DATACAT_JANITOR_IMAGE_BASE}${avatar}`;
     const safety = window.isUrlSafeForDownload?.(url);
     if (safety && !safety.ok) return null;
@@ -974,168 +978,4 @@ function normalizeMeiliHit(hit) {
         totalTokens: hit.totalToken || 0,
         _source: 'meilisearch',
     };
-}
-
-// ========================================
-// SAUCEPAN (saucepan.ai search API)
-// ========================================
-
-// Saucepan calls go through cl-helper (/saucepan-proxy/*), not ST's /proxy/.
-// Reason: Saucepan responds with zstd-compressed bodies; ST's /proxy/ forwards
-// them without the Content-Encoding header, leaving the browser unable to
-// decode them. cl-helper negotiates gzip/br/deflate (and falls back to native
-// zstd decompress) before returning plain JSON to the client.
-const SAUCEPAN_PROXY_BASE = `${CL_HELPER_PLUGIN_BASE}/saucepan-proxy`;
-const SAUCEPAN_CDN_BASE = 'https://cdn.saucepan.ai/images';
-
-const SAUCEPAN_ORDER_MAP = {
-    saucepan_new: 'created',
-    saucepan_trending: 'trending',
-    saucepan_popular: 'popularity',
-};
-
-async function saucepanFetch(method, apiPath, body) {
-    if (!_apiRequest) throw new Error('Saucepan: apiRequest not bound (cl-helper required)');
-    const url = `${SAUCEPAN_PROXY_BASE}${apiPath}`;
-    return method === 'POST'
-        ? _apiRequest(url, 'POST', body)
-        : _apiRequest(url);
-}
-
-/**
- * Search Saucepan companions via the Saucepan API (proxied through cl-helper).
- * Returns results normalized to DataCat-compatible shape.
- * @param {Object} opts
- * @param {string} [opts.search='']
- * @param {number} [opts.page=1]
- * @param {number} [opts.limit=96]
- * @param {string} [opts.sort='saucepan_new']
- * @param {boolean} [opts.openDefinitionOnly=true]
- * @param {string[]} [opts.tags=[]] - Tag slugs to include (AND match)
- * @param {string[]} [opts.excludedTags=[]] - Tag slugs to exclude
- * @returns {Promise<{characters: Object[], totalCount: number, totalPages: number}>}
- */
-export async function searchSaucepan(opts = {}) {
-    const {
-        search = '',
-        page = 1,
-        limit = 96,
-        sort = 'saucepan_new',
-        openDefinitionOnly = true,
-        tags = [],
-        excludedTags = [],
-    } = opts;
-    const orderBy = SAUCEPAN_ORDER_MAP[sort] || 'created';
-    const offset = Math.max(0, (page - 1) * limit);
-
-    const body = {
-        text_search: search || null,
-        tags: Array.isArray(tags) ? tags : [],
-        excluded_tags: Array.isArray(excludedTags) ? excludedTags : [],
-        fandom_tags: [],
-        excluded_fandom_tags: [],
-        match_all_fandom_tags: false,
-        limit,
-        offset,
-        sus: true,
-        extra_spicy: null,
-        order_by: orderBy,
-        asc: false,
-        posted_at_from: null,
-        posted_at_to: null,
-        match_all_tags: true,
-        hide_hidden_content: false,
-        open_definition_only: openDefinitionOnly,
-    };
-
-    let response;
-    try {
-        response = await saucepanFetch('POST', '/api/v1/search', body);
-    } catch (err) {
-        throw new Error(`Saucepan search failed: ${err.message}`);
-    }
-    if (!response.ok) throw new Error(`Saucepan HTTP ${response.status}`);
-
-    const data = await response.json();
-    const companions = data?.companions || [];
-    const totalCount = data?.total_count || 0;
-    const totalPages = limit > 0 ? Math.ceil(totalCount / limit) : 0;
-
-    return {
-        characters: companions.map(normalizeSaucepanHit),
-        totalCount,
-        totalPages,
-    };
-}
-
-function normalizeSaucepanHit(hit) {
-    const imageId = hit?.image?.id || '';
-    const avatar = imageId ? `${SAUCEPAN_CDN_BASE}/${imageId}/card` : '';
-    const tags = Array.isArray(hit.tags) ? hit.tags : [];
-
-    return {
-        character_id: hit.id,
-        name: hit.display_name || hit.name || 'Unknown',
-        avatar,
-        description: hit.short_description || '',
-        tags,
-        creator_name: hit.author_handle || '',
-        creator_id: hit.author_id || '',
-        createdAt: hit.posted_at || '',
-        isNsfw: !!hit.sus,
-        totalTokens: hit.card_token_count || 0,
-        chat_count: hit.chat_count || 0,
-        message_count: hit.interaction_count || 0,
-        favorite_count: hit.favorite_count || 0,
-        portrait_count: hit.portrait_count || 0,
-        scenario_count: hit.scenario_count || 0,
-        lorebook_count: hit.lorebook_count || 0,
-        locked_starting_message: !!hit.locked_starting_message,
-        primary_content_source_kind: 'saucepan',
-        _source: 'saucepan',
-    };
-}
-
-/**
- * Fetch all companions authored by a Saucepan handle.
- * The endpoint returns the full list in one response (no real pagination
- * support: limit/offset are ignored server-side, total_count == count).
- * @param {string} handle - Saucepan author handle
- * @returns {Promise<{characters: Object[], totalCount: number}>}
- */
-export async function fetchSaucepanCompanionsOfUser(handle) {
-    if (!handle) return { characters: [], totalCount: 0 };
-    let response;
-    try {
-        response = await saucepanFetch('GET', `/api/v1/companions-of-user?handle=${encodeURIComponent(handle)}`);
-    } catch (err) {
-        throw new Error(`Saucepan creator fetch failed: ${err.message}`);
-    }
-    if (!response.ok) throw new Error(`Saucepan HTTP ${response.status}`);
-    const data = await response.json();
-    const companions = data?.companions || [];
-    return {
-        characters: companions.map(normalizeSaucepanHit),
-        totalCount: data?.total_count ?? companions.length,
-    };
-}
-
-/**
- * Fetch a single Saucepan companion's detail by id.
- * Returns the raw `companion` object, or null on failure.
- * The detail endpoint exposes `open_definition` (boolean), which the
- * search/listing endpoint does not include.
- * @param {string} id
- * @returns {Promise<Object|null>}
- */
-export async function fetchSaucepanCompanion(id) {
-    if (!id) return null;
-    try {
-        const response = await saucepanFetch('GET', `/api/v1/companion?id=${encodeURIComponent(id)}`);
-        if (!response.ok) return null;
-        const data = await response.json();
-        return data?.companion || null;
-    } catch {
-        return null;
-    }
 }

--- a/modules/providers/datacat/datacat-browse.js
+++ b/modules/providers/datacat/datacat-browse.js
@@ -26,14 +26,20 @@ import {
     fetchExtractionStatus,
     searchMeiliJanny,
     fetchHampterCharacters,
-    searchSaucepan,
-    fetchSaucepanCompanion,
-    fetchSaucepanCompanionsOfUser,
     JANNY_TAG_MAP,
     pickRecoveryVariant,
     createFlareSolverrSession,
     destroyFlareSolverrSession,
 } from './datacat-api.js';
+import {
+    searchSaucepan,
+    fetchSaucepanCompanion,
+    fetchSaucepanCompanionsOfUser,
+    fetchSaucepanV2Card,
+    buildSaucepanCharacterFromHit,
+    hasSaucepanToken,
+    resolveSaucepanImageUrl,
+} from './saucepan-api.js';
 
 const {
     onElement: on,
@@ -1664,25 +1670,6 @@ async function lookupExternalCharacter(charId, originalUrl, source = 'janitor') 
     showExtractionPanel(charId, originalUrl, source);
 }
 
-// Saucepan card click: try DataCat lookup without resetting browse state.
-// If found, open preview. If not, prompt extraction in a modal-like overlay
-// so the user can return to their saucepan grid afterwards.
-async function openSaucepanCardPreview(hit) {
-    // Retained for any callers that still want the lookup-then-extract flow.
-    // The standard grid click now goes through openPreviewModal() directly,
-    // which surfaces the inline extraction CTA when the DataCat lookup fails.
-    const charId = String(getCharId(hit));
-    const url = `https://saucepan.ai/companion/${charId}`;
-    try {
-        const character = await fetchDatacatCharacter(charId, 'saucepan');
-        if (character) {
-            openPreviewModal(character);
-            return;
-        }
-    } catch { /* not found on DataCat */ }
-    showExtractionPanel(charId, url, 'saucepan');
-}
-
 function showExtractionPanel(charId, originalUrl, source = 'janitor') {
     const grid = document.getElementById('datacatGrid');
     if (!grid) return;
@@ -2670,9 +2657,18 @@ async function fetchAndPopulateDetails(hit, token) {
     const downloadPromise = fetchDatacatDownload(charId, hitSource).catch(() => null);
 
     try {
-        const character = hit._fullCharacter || await fetchDatacatCharacter(charId, hitSource);
+        let character = hit._fullCharacter || await fetchDatacatCharacter(charId, hitSource);
 
         if (token !== datacatDetailFetchToken) return;
+
+        // DataCat doesn't know this Saucepan character. With a Saucepan token
+        // we can pull the definition natively and render/import it without
+        // DataCat's extraction service.
+        if (!character && isSaucepanHit && hasSaucepanToken()) {
+            const v2Card = await fetchSaucepanV2Card(hit).catch(() => null);
+            if (token !== datacatDetailFetchToken) return;
+            if (v2Card) character = buildSaucepanCharacterFromHit(hit, v2Card);
+        }
 
         // Hide the loading indicator
         const defLoading = document.getElementById('datacatCharDefinitionLoading');
@@ -2827,7 +2823,8 @@ async function fetchAndPopulateDetails(hit, token) {
                 gallerySection.style.display = 'block';
                 if (galleryLabel) galleryLabel.textContent = `(${portraits.length})`;
                 galleryGrid.innerHTML = portraits.map(p => {
-                    const url = p?.image?.highres_url;
+                    // CORP headers block hotlinking; route through cl-helper.
+                    const url = resolveSaucepanImageUrl(p?.image?.highres_url);
                     if (!url) return '';
                     const title = p?.description || p?.name || 'Gallery image';
                     return `<div class="browse-gallery-cell"><img class="browse-gallery-thumb" src="${escapeHtml(url)}" alt="${escapeHtml(title)}" title="${escapeHtml(title)}" loading="lazy" onload="this.parentElement.classList.add('loaded')" onerror="this.parentElement.classList.add('load-failed')"></div>`;

--- a/modules/providers/datacat/datacat-provider.js
+++ b/modules/providers/datacat/datacat-provider.js
@@ -400,6 +400,11 @@ class DatacatProvider extends ProviderBase {
 
     getCharacterUrl(linkInfo) {
         if (!linkInfo?.id) return null;
+        // Saucepan characters (especially natively-extracted ones) may not
+        // exist on DataCat, so link to their actual source page.
+        if (linkInfo.sourceKind === 'saucepan') {
+            return `https://saucepan.ai/companion/${linkInfo.id}`;
+        }
         return `https://datacat.run/characters/${linkInfo.id}`;
     }
 

--- a/modules/providers/datacat/datacat-provider.js
+++ b/modules/providers/datacat/datacat-provider.js
@@ -6,7 +6,7 @@
 
 import { ProviderBase } from '../provider-interface.js';
 import CoreAPI from '../../core-api.js';
-import { assignGalleryId, importFromPng, fetchWithProxy } from '../provider-utils.js';
+import { assignGalleryId, importFromPng, fetchWithProxy, CL_HELPER_PLUGIN_BASE } from '../provider-utils.js';
 import datacatBrowseView from './datacat-browse.js';
 import {
     DATACAT_API_BASE,
@@ -28,6 +28,14 @@ import {
     submitExtraction,
     fetchExtractionStatus,
 } from './datacat-api.js';
+import {
+    setApiRequest as setSaucepanApiRequest,
+    setSaucepanTokenGetter,
+    hasSaucepanToken,
+    fetchSaucepanCompanion,
+    submitSaucepanExtraction,
+    buildV2FromSaucepan,
+} from './saucepan-api.js';
 
 let api = null;
 
@@ -78,7 +86,28 @@ class DatacatProvider extends ProviderBase {
         super.init(coreAPI);
         api = coreAPI;
         setApiRequest(coreAPI.apiRequest);
+        setSaucepanApiRequest(coreAPI.apiRequest);
         setSavedTokenGetter(() => coreAPI.getSetting('datacatToken') || null);
+        setSaucepanTokenGetter(() => coreAPI.getSetting('saucepanToken') || null);
+
+        // Push any persisted Saucepan token into cl-helper so search and
+        // other stateless proxy calls are authenticated without requiring a
+        // manual login after every server restart.
+        const saucepanToken = coreAPI.getSetting('saucepanToken');
+        if (saucepanToken) {
+            try {
+                await coreAPI.apiRequest(
+                    `${CL_HELPER_PLUGIN_BASE}/saucepan-set-token`,
+                    'POST',
+                    { token: saucepanToken },
+                );
+            } catch (e) {
+                console.warn(
+                    '[DatacatProvider] Failed to push Saucepan token:',
+                    e.message,
+                );
+            }
+        }
     }
 
     // ── View ────────────────────────────────────────────────
@@ -170,6 +199,39 @@ class DatacatProvider extends ProviderBase {
         if (!linkInfo?.id) return null;
         const sk = linkInfo.sourceKind || null;
         try {
+            // For Saucepan, try native extraction first if a token is available.
+            if (sk === 'saucepan' && hasSaucepanToken()) {
+                const companion = await fetchSaucepanCompanion(linkInfo.id);
+                if (companion) {
+                    const hit = {
+                        id: companion.id || linkInfo.id,
+                        character_id: companion.id || linkInfo.id,
+                        name: companion.name || 'Unknown',
+                        display_name: companion.display_name || companion.name || 'Unknown',
+                        avatar: companion.image?.highres_url || companion.image?.url || '',
+                        description: companion.short_description || '',
+                        tags: Array.isArray(companion.tags) ? companion.tags : [],
+                        creator_name: companion.author_handle || '',
+                        creator_id: companion.author_id || '',
+                    };
+                    const extractResult = await submitSaucepanExtraction(
+                        `https://saucepan.ai/companion/${linkInfo.id}`,
+                    );
+                    if (extractResult.success) {
+                        const result = buildV2FromSaucepan(hit, extractResult);
+                        if (result) {
+                            result._listingName = this.getListingName(hit);
+                            return result;
+                        }
+                    } else {
+                        api?.debugLog?.(
+                            '[DatacatProvider] native Saucepan extraction failed:',
+                            extractResult.error,
+                        );
+                    }
+                }
+            }
+
             // Try the download endpoint first (closest to V2 format)
             const downloadData = await fetchDatacatDownload(linkInfo.id, sk);
             if (downloadData?.data) {
@@ -461,13 +523,20 @@ class DatacatProvider extends ProviderBase {
 
             const characterName = character.chat_name || character.name || 'Unnamed';
 
-            // Try download endpoint for best V2 mapping
+            // Natively-extracted Saucepan cards already carry a fully-built V2
+            // card (body, greetings, example dialogue, prompts). DataCat has no
+            // copy to download, so use it directly rather than rebuilding.
             let characterCard;
-            const downloadData = await fetchDatacatDownload(charId);
-            if (downloadData?.data) {
-                characterCard = buildV2FromDownload(downloadData, character);
+            if (character._source === 'saucepan' && character.chara_card_v2_json?.data) {
+                characterCard = character.chara_card_v2_json;
             } else {
-                characterCard = buildV2FromDatacat(character);
+                // Try download endpoint for best V2 mapping
+                const downloadData = await fetchDatacatDownload(charId);
+                if (downloadData?.data) {
+                    characterCard = buildV2FromDownload(downloadData, character);
+                } else {
+                    characterCard = buildV2FromDatacat(character);
+                }
             }
 
             if (!characterCard?.data) throw new Error('Failed to build character card');
@@ -544,4 +613,102 @@ window.datacatRefreshToken = async () => {
 
 window.datacatClearSession = async () => {
     return clearDcSession();
+};
+
+// Window-exposed Saucepan session management (called by settings panel in library.js).
+// The token is persisted in the 'saucepanToken' setting — that setting is what
+// hasSaucepanToken()/native extraction key off — and mirrored into cl-helper's
+// in-memory store for proxy auth.
+window.saucepanLogin = async (handle, password) => {
+    const pluginOk = await checkDcPluginAvailable();
+    if (!pluginOk) return { ok: false, error: 'cl-helper plugin not available' };
+    try {
+        const resp = await api.apiRequest(
+            `${CL_HELPER_PLUGIN_BASE}/saucepan-login`,
+            'POST',
+            { handle, password },
+        );
+        if (!resp.ok) {
+            const text = await resp.text().catch(() => '');
+            return { ok: false, error: `HTTP ${resp.status}: ${text.slice(0, 200)}` };
+        }
+        const data = await resp.json();
+        if (data?.ok && data.token) {
+            CoreAPI.setSetting('saucepanToken', data.token);
+        }
+        return data;
+    } catch (e) {
+        return { ok: false, error: e.message };
+    }
+};
+
+window.saucepanSetToken = async (token) => {
+    const trimmed = (token || '').trim();
+    if (!trimmed) return { ok: false, error: 'Token is empty' };
+    CoreAPI.setSetting('saucepanToken', trimmed);
+    const pluginOk = await checkDcPluginAvailable();
+    if (!pluginOk) return { ok: false, error: 'Saved locally, but cl-helper plugin not available' };
+    try {
+        const resp = await api.apiRequest(
+            `${CL_HELPER_PLUGIN_BASE}/saucepan-set-token`,
+            'POST',
+            { token: trimmed },
+        );
+        if (!resp.ok) {
+            const text = await resp.text().catch(() => '');
+            return { ok: false, error: `HTTP ${resp.status}: ${text.slice(0, 200)}` };
+        }
+        return await resp.json();
+    } catch (e) {
+        return { ok: false, error: e.message };
+    }
+};
+
+window.saucepanValidateSession = async () => {
+    const pluginOk = await checkDcPluginAvailable();
+    if (!pluginOk)
+        return { valid: false, reason: 'cl-helper plugin not available' };
+    try {
+        // Resync the persisted token first: cl-helper only holds it in
+        // memory, so a plugin reload or ST restart loses it.
+        const saved = CoreAPI.getSetting('saucepanToken');
+        if (saved) {
+            try {
+                await api.apiRequest(
+                    `${CL_HELPER_PLUGIN_BASE}/saucepan-set-token`,
+                    'POST',
+                    { token: saved },
+                );
+            } catch { /* validate reports the failure */ }
+        }
+        const resp = await api.apiRequest(
+            `${CL_HELPER_PLUGIN_BASE}/saucepan-validate`,
+        );
+        if (!resp.ok) {
+            const text = await resp.text().catch(() => '');
+            return {
+                valid: false,
+                reason: `HTTP ${resp.status}: ${text.slice(0, 200)}`,
+            };
+        }
+        return await resp.json();
+    } catch (e) {
+        return { valid: false, reason: e.message };
+    }
+};
+
+window.saucepanClearSession = async () => {
+    // Drop the persisted token even when cl-helper is unreachable.
+    CoreAPI.setSetting('saucepanToken', null);
+    const pluginOk = await checkDcPluginAvailable();
+    if (!pluginOk) return false;
+    try {
+        const resp = await api.apiRequest(
+            `${CL_HELPER_PLUGIN_BASE}/saucepan-clear-token`,
+            'POST',
+        );
+        return resp.ok;
+    } catch {
+        return false;
+    }
 };

--- a/modules/providers/datacat/saucepan-api.js
+++ b/modules/providers/datacat/saucepan-api.js
@@ -1,0 +1,400 @@
+// Saucepan (saucepan.ai) client API - used via the DataCat provider.
+//
+// Saucepan is surfaced as a source-kind within DataCat rather than a standalone
+// provider, but its API is distinct enough (search, companion detail, native
+// fragment-based definition extraction, CDN image proxying) to live on its own.
+//
+// All calls go through cl-helper (/plugins/cl-helper/saucepan-*), never ST's
+// /proxy/: Saucepan responds with zstd-compressed bodies that ST's proxy
+// forwards without a Content-Encoding header, leaving the browser unable to
+// decode them. cl-helper negotiates gzip/br/deflate (falling back to native
+// zstd) and performs the auth'd definition fetch + fragment reassembly.
+
+import { CL_HELPER_PLUGIN_BASE } from '../provider-utils.js';
+
+// ========================================
+// CONSTANTS
+// ========================================
+
+const SAUCEPAN_PROXY_BASE = `${CL_HELPER_PLUGIN_BASE}/saucepan-proxy`;
+
+// Saucepan CDN images can't be hotlinked: the CDN answers with
+// Cross-Origin-Resource-Policy: same-origin, so the browser refuses to render
+// them from our origin. Route them through cl-helper's proxy instead. Images
+// live at saucepan.ai/cdn/{imageId}/card; plugin routes are prefixed with /api.
+export const SAUCEPAN_CDN_PROXY_BASE = `/api${CL_HELPER_PLUGIN_BASE}/saucepan-proxy/cdn/`;
+
+const SAUCEPAN_ORDER_MAP = {
+    saucepan_new: 'created',
+    saucepan_trending: 'trending',
+    saucepan_popular: 'popularity',
+};
+
+// ========================================
+// TRANSPORT
+// ========================================
+
+let _apiRequest = null;
+let _getSaucepanToken = null;
+
+/**
+ * Bind the CoreAPI.apiRequest function for proxied requests. Called from the
+ * DataCat provider's init() alongside the DataCat binding.
+ */
+export function setApiRequest(fn) { _apiRequest = fn; }
+
+/**
+ * Bind a getter that returns the persisted Saucepan Bearer token (or null).
+ * Used by native extraction to authenticate the definition fetch.
+ */
+export function setSaucepanTokenGetter(fn) { _getSaucepanToken = fn; }
+
+/**
+ * Return true if a Saucepan token appears to be configured.
+ * @returns {boolean}
+ */
+export function hasSaucepanToken() { return !!(_getSaucepanToken?.() ?? null); }
+
+async function saucepanFetch(method, apiPath, body) {
+    if (!_apiRequest) throw new Error('Saucepan: apiRequest not bound (cl-helper required)');
+    const url = `${SAUCEPAN_PROXY_BASE}${apiPath}`;
+    return method === 'POST'
+        ? _apiRequest(url, 'POST', body)
+        : _apiRequest(url);
+}
+
+// ========================================
+// IMAGES
+// ========================================
+
+/**
+ * Rewrite a Saucepan CDN image URL to the local cl-helper proxy path.
+ * Non-Saucepan URLs are returned unchanged.
+ * @param {string} url
+ * @returns {string}
+ */
+export function resolveSaucepanImageUrl(url) {
+    if (!url || typeof url !== 'string') return url;
+    if (url.startsWith('https://saucepan.ai/cdn/')) {
+        return url.replace('https://saucepan.ai/cdn/', SAUCEPAN_CDN_PROXY_BASE);
+    }
+    // Legacy CDN host found in older DataCat rows. The host no longer
+    // resolves, but its path shape maps 1:1 onto saucepan.ai/cdn/.
+    if (url.startsWith('https://cdn.saucepan.ai/images/')) {
+        return url.replace('https://cdn.saucepan.ai/images/', SAUCEPAN_CDN_PROXY_BASE);
+    }
+    // Proxy paths from earlier builds that lack the /api prefix.
+    if (url.startsWith(`${CL_HELPER_PLUGIN_BASE}/saucepan-proxy/cdn/`)) {
+        return `/api${url}`;
+    }
+    return url;
+}
+
+// ========================================
+// SEARCH / DETAIL
+// ========================================
+
+/**
+ * Search Saucepan companions via the Saucepan API (proxied through cl-helper).
+ * Returns results normalized to DataCat-compatible shape.
+ * @param {Object} opts
+ * @param {string} [opts.search='']
+ * @param {number} [opts.page=1]
+ * @param {number} [opts.limit=96]
+ * @param {string} [opts.sort='saucepan_new']
+ * @param {boolean} [opts.openDefinitionOnly=true]
+ * @param {string[]} [opts.tags=[]] - Tag slugs to include (AND match)
+ * @param {string[]} [opts.excludedTags=[]] - Tag slugs to exclude
+ * @returns {Promise<{characters: Object[], totalCount: number, totalPages: number}>}
+ */
+export async function searchSaucepan(opts = {}) {
+    const {
+        search = '',
+        page = 1,
+        limit = 96,
+        sort = 'saucepan_new',
+        openDefinitionOnly = true,
+        tags = [],
+        excludedTags = [],
+    } = opts;
+    const orderBy = SAUCEPAN_ORDER_MAP[sort] || 'created';
+    const offset = Math.max(0, (page - 1) * limit);
+
+    const body = {
+        text_search: search || null,
+        tags: Array.isArray(tags) ? tags : [],
+        excluded_tags: Array.isArray(excludedTags) ? excludedTags : [],
+        fandom_tags: [],
+        excluded_fandom_tags: [],
+        match_all_fandom_tags: false,
+        limit,
+        offset,
+        sus: true,
+        extra_spicy: null,
+        order_by: orderBy,
+        asc: false,
+        posted_at_from: null,
+        posted_at_to: null,
+        match_all_tags: true,
+        hide_hidden_content: false,
+        open_definition_only: openDefinitionOnly,
+    };
+
+    let response;
+    try {
+        response = await saucepanFetch('POST', '/api/v1/search', body);
+    } catch (err) {
+        throw new Error(`Saucepan search failed: ${err.message}`);
+    }
+    if (!response.ok) throw new Error(`Saucepan HTTP ${response.status}`);
+
+    const data = await response.json();
+    const companions = data?.companions || [];
+    const totalCount = data?.total_count || 0;
+    const totalPages = limit > 0 ? Math.ceil(totalCount / limit) : 0;
+
+    return {
+        characters: companions.map(normalizeSaucepanHit),
+        totalCount,
+        totalPages,
+    };
+}
+
+function normalizeSaucepanHit(hit) {
+    const imageId = hit?.image?.id || '';
+    const avatar = imageId ? `${SAUCEPAN_CDN_PROXY_BASE}${imageId}/card` : '';
+    const tags = Array.isArray(hit.tags) ? hit.tags : [];
+
+    return {
+        character_id: hit.id,
+        name: hit.display_name || hit.name || 'Unknown',
+        avatar,
+        description: hit.short_description || '',
+        tags,
+        creator_name: hit.author_handle || '',
+        creator_id: hit.author_id || '',
+        createdAt: hit.posted_at || '',
+        isNsfw: !!hit.sus,
+        totalTokens: hit.card_token_count || 0,
+        chat_count: hit.chat_count || 0,
+        message_count: hit.interaction_count || 0,
+        favorite_count: hit.favorite_count || 0,
+        portrait_count: hit.portrait_count || 0,
+        scenario_count: hit.scenario_count || 0,
+        lorebook_count: hit.lorebook_count || 0,
+        locked_starting_message: !!hit.locked_starting_message,
+        primary_content_source_kind: 'saucepan',
+        _source: 'saucepan',
+    };
+}
+
+/**
+ * Fetch all companions authored by a Saucepan handle.
+ * The endpoint returns the full list in one response (no real pagination
+ * support: limit/offset are ignored server-side, total_count == count).
+ * @param {string} handle - Saucepan author handle
+ * @returns {Promise<{characters: Object[], totalCount: number}>}
+ */
+export async function fetchSaucepanCompanionsOfUser(handle) {
+    if (!handle) return { characters: [], totalCount: 0 };
+    let response;
+    try {
+        response = await saucepanFetch('GET', `/api/v1/companions-of-user?handle=${encodeURIComponent(handle)}`);
+    } catch (err) {
+        throw new Error(`Saucepan creator fetch failed: ${err.message}`);
+    }
+    if (!response.ok) throw new Error(`Saucepan HTTP ${response.status}`);
+    const data = await response.json();
+    const companions = data?.companions || [];
+    return {
+        characters: companions.map(normalizeSaucepanHit),
+        totalCount: data?.total_count ?? companions.length,
+    };
+}
+
+/**
+ * Fetch a single Saucepan companion's detail by id.
+ * Returns the raw `companion` object, or null on failure.
+ * The detail endpoint exposes `open_definition` (boolean), which the
+ * search/listing endpoint does not include.
+ * @param {string} id
+ * @returns {Promise<Object|null>}
+ */
+export async function fetchSaucepanCompanion(id) {
+    if (!id) return null;
+    try {
+        const response = await saucepanFetch('GET', `/api/v1/companion?id=${encodeURIComponent(id)}`);
+        if (!response.ok) return null;
+        const data = await response.json();
+        return data?.companion || null;
+    } catch {
+        return null;
+    }
+}
+
+// ========================================
+// NATIVE EXTRACTION
+// ========================================
+
+/**
+ * Submit a Saucepan companion URL for native extraction via cl-helper.
+ * Requires a Saucepan Bearer token (login or manually pasted).
+ * @param {string} companionUrl - Full Saucepan companion URL
+ * @returns {Promise<{success: boolean, companionId?: string, assembled?: Object, greetings?: Object[], error?: string}>}
+ */
+export async function submitSaucepanExtraction(companionUrl) {
+    if (!_apiRequest) throw new Error('Saucepan: apiRequest not bound');
+    // Send the persisted token when we have one; cl-helper falls back to its
+    // own stored token (e.g. from a login this session) and 401s if neither
+    // side has one.
+    const token = _getSaucepanToken?.() ?? null;
+    try {
+        const resp = await _apiRequest(
+            `${CL_HELPER_PLUGIN_BASE}/saucepan-extract`,
+            'POST',
+            token ? { url: companionUrl, token } : { url: companionUrl },
+        );
+        if (!resp.ok) {
+            const errText = await resp.text();
+            console.error(
+                '[DataCat] saucepan-extract error:',
+                resp.status,
+                errText.substring(0, 200),
+            );
+            return {
+                success: false,
+                error: `Server returned ${resp.status}: ${errText.substring(0, 100)}`,
+            };
+        }
+        const data = await resp.json();
+        if (data?.error) {
+            return { success: false, error: data.error };
+        }
+        return {
+            success: true,
+            companionId: data.companionId,
+            assembled: data.assembled,
+            greetings: data.greetings,
+        };
+    } catch (e) {
+        console.error('[DataCat] submitSaucepanExtraction failed:', e);
+        return { success: false, error: e.message };
+    }
+}
+
+/**
+ * Build a V2 character card from native Saucepan extraction data.
+ * Returns null when the definition carries no usable body so callers can
+ * fall back to DataCat's aggregated copy instead of importing an empty card.
+ *
+ * Section/greeting -> V2 field mapping:
+ *   'Companion Core'                  -> description (character body)
+ *   'Example Dialogue'                -> mes_example
+ *   'Advanced Prompt'                 -> system_prompt
+ *   'Response Formatting Instructions'-> post_history_instructions
+ *   greetings[0]                      -> first_mes
+ *   greetings[1..]                    -> alternate_greetings
+ * @param {Object} hit - Normalized Saucepan hit from search/companions endpoint
+ * @param {Object} extractData - Response from /saucepan-extract { assembled: {...}, greetings: [{title, text}] }
+ * @returns {Object|null}
+ */
+export function buildV2FromSaucepan(hit, extractData) {
+    const assembled = extractData?.assembled;
+    if (!hit || !assembled) return null;
+    const description = assembled['Companion Core'] || '';
+    if (!description) {
+        console.warn(
+            '[DataCat] Companion Core section not found in Saucepan extraction. Available sections:',
+            Object.keys(assembled).join(', ') || '(none)',
+        );
+        return null;
+    }
+    const mesExample = assembled['Example Dialogue'] || '';
+    const systemPrompt = assembled['Advanced Prompt'] || '';
+    const postHistory = assembled['Response Formatting Instructions'] || '';
+
+    // Starting scenarios become greetings: the first is first_mes, the rest
+    // are alternate greetings. cl-helper already assembled and filtered them.
+    const greetingTexts = Array.isArray(extractData.greetings)
+        ? extractData.greetings.map(g => g?.text || '').filter(Boolean)
+        : [];
+    const firstMes = greetingTexts[0] || '';
+    const alternateGreetings = greetingTexts.slice(1);
+
+    const tagNames = Array.isArray(hit.tags) ? hit.tags : [];
+
+    return {
+        spec: 'chara_card_v2',
+        spec_version: '2.0',
+        data: {
+            name: hit.display_name || hit.name || 'Unknown',
+            description,
+            personality: '',
+            scenario: '',
+            first_mes: firstMes,
+            mes_example: mesExample,
+            system_prompt: systemPrompt,
+            post_history_instructions: postHistory,
+            creator_notes: hit.description || '',
+            creator: hit.creator_name || '',
+            character_version: '1.0',
+            tags: tagNames,
+            alternate_greetings: alternateGreetings,
+            extensions: {
+                datacat: {
+                    id: hit.character_id || hit.id,
+                    sourceKind: 'saucepan',
+                    creatorId: hit.creator_id || null,
+                    creatorName: hit.creator_name || null,
+                },
+            },
+        },
+    };
+}
+
+/**
+ * Build a DataCat-compatible character object from a Saucepan hit + native extraction.
+ * This lets the browse preview modal render native-extracted Saucepan cards the same
+ * way it renders DataCat-aggregated ones.
+ * @param {Object} hit - Normalized Saucepan hit
+ * @param {Object} v2Card - V2 card from buildV2FromSaucepan
+ * @returns {Object}
+ */
+export function buildSaucepanCharacterFromHit(hit, v2Card) {
+    const description = v2Card?.data?.description || '';
+    return {
+        character_id: hit.character_id || hit.id,
+        name: hit.display_name || hit.name || 'Unknown',
+        avatar: hit.avatar || '',
+        description,
+        short_description: hit.description || '',
+        tags: hit.tags || [],
+        creator_name: hit.creator_name || '',
+        creator_id: hit.creator_id || '',
+        primary_content_source_kind: 'saucepan',
+        companion_snapshot: {
+            full_description: hit.description || '',
+        },
+        chara_card_v2_json: v2Card,
+        chat_count: hit.chat_count || 0,
+        message_count: hit.message_count || 0,
+        totalTokens: hit.totalTokens || 0,
+        _source: 'saucepan',
+    };
+}
+
+/**
+ * Fetch a Saucepan companion's full definition and build a V2 card.
+ * @param {Object} hit - Normalized Saucepan hit (must have character_id or id)
+ * @returns {Promise<Object|null>} V2 card or null
+ */
+export async function fetchSaucepanV2Card(hit) {
+    if (!hit?.character_id && !hit?.id) return null;
+    const companionUrl = `https://saucepan.ai/companion/${hit.character_id || hit.id}`;
+    const result = await submitSaucepanExtraction(companionUrl);
+    if (!result.success) {
+        console.warn('[DataCat] Native Saucepan extraction failed:', result.error);
+        return null;
+    }
+    return buildV2FromSaucepan(hit, result);
+}

--- a/modules/providers/provider-utils.js
+++ b/modules/providers/provider-utils.js
@@ -161,7 +161,14 @@ async function errorBodySnippet(resp) {
  * @returns {Promise<Response>}
  */
 export async function fetchWithProxy(url, opts = {}) {
-    const origin = new URL(url).origin;
+    const origin = new URL(url, window.location.origin).origin;
+    // Same-origin URLs (e.g. cl-helper proxy paths like
+    // /api/plugins/cl-helper/saucepan-proxy/cdn/...) never need ST's /proxy/.
+    if (origin === window.location.origin) {
+        const r = await fetch(url, opts);
+        if (!r.ok) throw new Error(`HTTP ${r.status}${await errorBodySnippet(r)}`);
+        return r;
+    }
     if (!_proxyOrigins.has(origin)) {
         let directResponse;
         try {


### PR DESCRIPTION
DataCat disabled Saucepan character retrieval (`SAUCEPAN_RETRIEVAL_DISABLED`). This adds native Saucepan extraction directly from saucepan.ai, proxied through cl-helper, so Saucepan characters can be browsed, previewed, and imported without DataCat.

## cl-helper (`extras/cl-helper/index.js`)
- Routes: `saucepan-login`, `saucepan-set-token`, `saucepan-clear-token`, `saucepan-validate`, `saucepan-extract`, and a `saucepan-proxy/*` passthrough for search/companions plus CDN images.
- **Definition reassembly:** Saucepan ships companion definitions as a shuffled fragment list padded with decoy fragments, so a naive text-join is garbled. Real fragments are recovered by validating each fragment's `proof` against an FNV-1a hash of its text (seeded from the section `mask` and `key ^ mask`), then ordering the survivors by `key ^ mask`.
- **Greetings:** starting scenarios come from the v2 companion endpoint (`/api/v2/companions/{id}`) and are reassembled the same way — the definition endpoint doesn't include them.
- **Token validation** hits the auth-gated definition endpoint; the search endpoint is anonymous and can't prove a token is valid.
- **CDN images** are proxied to sidestep Saucepan's `Cross-Origin-Resource-Policy: same-origin` header (which blocks hotlinking), with a size cap and forwarded cache headers.

## Client (`modules/providers/datacat/`)
- **`saucepan-api.js`** (new module): Saucepan search, companion detail, native extraction, V2 card building, and CDN image URL rewriting — kept separate from the DataCat API surface.
- Section/greeting → V2 mapping: `Companion Core` → description, `Example Dialogue` → mes_example, `Advanced Prompt` → system_prompt, `Response Formatting Instructions` → post_history_instructions, scenarios → first_mes + alternate_greetings.
- `datacat-provider.js`: native-first extraction for linked Saucepan characters and on import (uses the prebuilt card directly); pushes the saved token into cl-helper on init so it survives restarts.
- `datacat-browse.js`: native extraction in the browse preview modal; portraits routed through the CDN proxy.
- `provider-utils.js`: `fetchWithProxy` now handles same-origin proxy paths (avatar download).

## Settings
- Saucepan account panel under the DataCat provider: handle/password login or a pasted Bearer token, with validate and clear.

## Testing
Verified end-to-end against live saucepan.ai: login, token validation, search + CDN image proxying, and native extraction of multiple companions — description, first message / alternate greetings, example dialogue, and prompt fields all reassemble correctly.

## Notes
- A Saucepan Bearer token is required (handle/password login or paste from the browser); definitions and greetings are auth-gated.
- Fragment reassembly mirrors Saucepan's current client scheme; if they change it, extraction will need updating.
